### PR TITLE
feat: 일정 CRUD 기능 및 localStorage 저장 구현

### DIFF
--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -1,6 +1,7 @@
 import { useRecoilValue } from "recoil";
 import { categoryByIdSelector } from "../store/categorySelector";
 import { scheduleByIdSelector } from "../store/scheduleSelector";
+import { Link } from "react-router-dom";
 
 interface ScheduleProps {
   scheduleId: string;
@@ -14,11 +15,13 @@ export default function Schedule({ scheduleId, isMini = true }: ScheduleProps) {
   return (
     <>
       {isMini ? (
-        <div className="flex text-[1.1rem] font-bold">
-          <div className={`w-1 h-7 mr-2 ${categoryInfo.color}`} />
-          <p className="mr-7 text-gray-500">{schedule?.time}</p>
-          <p>{schedule?.title}</p>
-        </div>
+        <Link to="/schedule-form" state={{ scheduleId }}>
+          <div className="flex text-[1.1rem] font-bold">
+            <div className={`w-1 h-7 mr-2 ${categoryInfo.color}`} />
+            <p className="mr-7 text-gray-500">{schedule?.time}</p>
+            <p>{schedule?.title}</p>
+          </div>
+        </Link>
       ) : (
         <div className="flex items-center">
           <div className={`w-1 h-14 mr-5 ${categoryInfo.color}`}></div>

--- a/src/features/Calendar/Calendar.tsx
+++ b/src/features/Calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from "recoil";
 import { getSchedulesByMonthSelector } from "../../store/scheduleSelector";
-import { formatToDateString } from "../../utils/dateUtils";
+import { formatDateOnly } from "../../utils/dateUtils";
 import { categorySelector } from "../../store/categorySelector";
 
 interface CalendarProps {
@@ -81,7 +81,7 @@ export default function Calendar({ selectedDate, onDateChange }: CalendarProps) 
             const textColor =
               day === 0 ? "text-red-500" : day === 6 ? "text-blue-500" : "text-black";
             const opacity = isCurrentMonth ? "opacity-100" : "opacity-50";
-            const schedules = monthSchedules.filter((s) => s.date === formatToDateString(date));
+            const schedules = monthSchedules.filter((s) => s.date === formatDateOnly(date));
 
             return (
               <div key={idx} className="w-full flex flex-col items-center justify-center">

--- a/src/features/Calendar/CalendarScheduleList.tsx
+++ b/src/features/Calendar/CalendarScheduleList.tsx
@@ -1,14 +1,14 @@
 import { useRecoilValue } from "recoil";
 import { getSchedulesByDateSelector } from "../../store/scheduleSelector";
 import CalendarSchedule from "./CalendarSchedule";
-import { formatToKoreanDateWithoutYear, formatToDateString } from "../../utils/dateUtils";
+import { formatToKoreanDateWithoutYear, formatDateOnly } from "../../utils/dateUtils";
 
 interface Props {
   selectedDate: Date;
 }
 
 export default function CalendarScheduleList({ selectedDate }: Props) {
-  const dateStr = formatToDateString(selectedDate);
+  const dateStr = formatDateOnly(selectedDate);
   const schedules = useRecoilValue(getSchedulesByDateSelector(dateStr));
 
   return (

--- a/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
+++ b/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from "react";
-import PageHeader from "../../components/PageHeader";
-import Schedule from "../../components/Schedule";
 import { useLocation } from "react-router-dom";
 import { useRecoilValue } from "recoil";
+import PageHeader from "../../components/PageHeader";
+import Schedule from "../../components/Schedule";
 import { retrospectByScheduleIdSelector } from "../../store/retrospectSelector";
 import { formatDuration } from "../../utils/formatDuration";
 import { tagState } from "../../store/tagAtom";
 
 export default function RetrospectWritePage() {
-  const location = useLocation();
-  const scheduleId = location.state?.scheduleId;
+  const { state } = useLocation();
+  const scheduleId = state?.scheduleId;
 
   const retrospect = useRecoilValue(retrospectByScheduleIdSelector(scheduleId));
   const allTags = useRecoilValue(tagState);
@@ -19,13 +19,17 @@ export default function RetrospectWritePage() {
   const [showMore, setShowMore] = useState(false);
 
   useEffect(() => {
-    setNote(retrospect?.content ?? "");
-    setTags(retrospect?.tags ?? []);
-  }, []);
+    if (retrospect) {
+      setNote(retrospect.content ?? "");
+      setTags(retrospect.tags ?? []);
+    }
+  }, [retrospect]);
 
   const handleChangeTag = (tag: string) => {
     setTags((prev) => (prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]));
   };
+
+  const visibleTags = showMore ? allTags : allTags.slice(0, 7);
 
   return (
     <div>
@@ -38,6 +42,7 @@ export default function RetrospectWritePage() {
 
         <Schedule scheduleId={scheduleId} isMini={false} />
 
+        {/* 노트 작성 */}
         <div className="mt-6 mb-5">
           <label className="block mb-1 text-lg font-bold">노트</label>
           <textarea
@@ -48,13 +53,15 @@ export default function RetrospectWritePage() {
           />
         </div>
 
+        {/* 태그 선택 */}
         <div className="my-5">
           <label className="block mb-1 text-lg font-bold flex justify-between">
             태그
             <button className="text-sm px-3 py-1 border rounded">+추가</button>
           </label>
+
           <div className="flex flex-wrap gap-2 mb-2">
-            {(showMore ? allTags : allTags.slice(0, 7)).map((tag) => (
+            {visibleTags.map((tag) => (
               <button
                 key={tag}
                 onClick={() => handleChangeTag(tag)}
@@ -76,6 +83,7 @@ export default function RetrospectWritePage() {
         </div>
       </section>
 
+      {/* 저장 버튼 */}
       <div className="fixed bottom-0 left-0 right-0 w-full bg-white">
         <button
           className="m-6 w-[90%] py-3 bg-black font-bold text-white rounded-lg shadow-lg"

--- a/src/store/categoryAtom.ts
+++ b/src/store/categoryAtom.ts
@@ -1,11 +1,17 @@
 import { atom } from "recoil";
 import { CategoryType } from "../types/category";
+import { localStorageEffect } from "./utils/localStorageEffect";
+
+const CATEGORY_KEY = "focuslog_categories";
+
+const defaultCategories: CategoryType[] = [
+  { id: 1, label: "Study", color: "bg-blue-500" },
+  { id: 2, label: "Exercise", color: "bg-green-500" },
+  { id: 3, label: "Meeting", color: "bg-purple-500" },
+];
 
 export const categoryState = atom<CategoryType[]>({
   key: "categoryState",
-  default: [
-    { id: 1, label: "공부", color: "bg-blue-500" },
-    { id: 2, label: "코딩", color: "bg-purple-500" },
-    { id: 3, label: "운동", color: "bg-green-500" },
-  ],
+  default: [],
+  effects: [localStorageEffect<CategoryType[]>(CATEGORY_KEY, defaultCategories)],
 });

--- a/src/store/retrospectAtom.ts
+++ b/src/store/retrospectAtom.ts
@@ -1,8 +1,11 @@
 import { atom } from "recoil";
 import { RetrospectType } from "../types/retrospect";
-import { mockRetrospects } from "./mockRetrospects";
+import { localStorageEffect } from "./utils/localStorageEffect";
+
+const RETROSPECT_KEY = "focuslog_retrospects";
 
 export const retrospectState = atom<RetrospectType[]>({
   key: "retrospectState",
-  default: mockRetrospects,
+  default: [],
+  effects: [localStorageEffect<RetrospectType[]>(RETROSPECT_KEY)],
 });

--- a/src/store/scheduleAtom.ts
+++ b/src/store/scheduleAtom.ts
@@ -1,8 +1,11 @@
 import { atom } from "recoil";
 import { ScheduleType } from "../types/schedule";
-import { mockSchedules } from "./mockSchedules";
+import { localStorageEffect } from "./utils/localStorageEffect";
+
+const STORAGE_KEY = "focuslog_schedules";
 
 export const scheduleState = atom<ScheduleType[]>({
   key: "scheduleState",
-  default: mockSchedules,
+  default: [],
+  effects: [localStorageEffect<ScheduleType[]>(STORAGE_KEY)],
 });

--- a/src/store/scheduleSelector.ts
+++ b/src/store/scheduleSelector.ts
@@ -1,7 +1,8 @@
 import { selector, selectorFamily } from "recoil";
 import { ScheduleType } from "../types/schedule";
 import { scheduleState } from "./scheduleAtom";
-import { formatToISOStringDate } from "../utils/dateUtils";
+import { formatDateOnly } from "../utils/dateUtils";
+import { sortSchedulesByTime } from "./utils/scheduleTimeSort";
 
 export const scheduleByIdSelector = selectorFamily<ScheduleType | undefined, string>({
   key: "retrospectByScheduleIdSelector",
@@ -17,9 +18,9 @@ export const todayScheduleSelector = selector<ScheduleType[]>({
   key: "todayScheduleSelector",
   get: ({ get }) => {
     const allSchedules = get(scheduleState);
-    const today = formatToISOStringDate(new Date());
+    const today = formatDateOnly(new Date());
 
-    return allSchedules.filter((item) => item.date === today);
+    return sortSchedulesByTime(allSchedules.filter((item) => item.date === today));
   },
 });
 
@@ -37,7 +38,7 @@ export const getSchedulesByDateSelector = selectorFamily<ScheduleType[], string>
     (targetDate: string) =>
     ({ get }) => {
       const allSchedules = get(scheduleState);
-      return allSchedules.filter((schedule) => schedule.date === targetDate);
+      return sortSchedulesByTime(allSchedules.filter((schedule) => schedule.date === targetDate));
     },
 });
 

--- a/src/store/tagAtom.ts
+++ b/src/store/tagAtom.ts
@@ -1,18 +1,12 @@
 import { atom } from "recoil";
+import { localStorageEffect } from "./utils/localStorageEffect";
+
+const TAG_KEY = "focuslog_tags";
+
+const defaultTags: string[] = ["집중됨", "뿌듯함", "힘듦", "피곤함"];
 
 export const tagState = atom<string[]>({
   key: "tagState",
-  default: [
-    "집중됨",
-    "뿌듯함",
-    "힘듦",
-    "피곤함",
-    "11111",
-    "2222",
-    "3333",
-    "44444",
-    "555",
-    "6ㅈㅂㅁㄷ",
-    "아무말",
-  ],
+  default: [],
+  effects: [localStorageEffect<string[]>(TAG_KEY, defaultTags)],
 });

--- a/src/store/utils/localStorageEffect.ts
+++ b/src/store/utils/localStorageEffect.ts
@@ -1,0 +1,22 @@
+export function localStorageEffect<T>(key: string, defaultValue?: T) {
+  return ({ setSelf, onSet }: any) => {
+    const savedValue = localStorage.getItem(key);
+
+    if (savedValue != null) {
+      try {
+        setSelf(JSON.parse(savedValue));
+      } catch (e) {
+        console.error(`Error parsing localStorage for ${key}`, e);
+        setSelf(defaultValue);
+      }
+    } else if (defaultValue) {
+      // 최초 진입 시 기본값을 저장
+      setSelf(defaultValue);
+      localStorage.setItem(key, JSON.stringify(defaultValue));
+    }
+
+    onSet((newValue: T) => {
+      localStorage.setItem(key, JSON.stringify(newValue));
+    });
+  };
+}

--- a/src/store/utils/scheduleTimeSort.ts
+++ b/src/store/utils/scheduleTimeSort.ts
@@ -1,0 +1,5 @@
+import { ScheduleType } from "../../types/schedule";
+
+export function sortSchedulesByTime(schedules: ScheduleType[]): ScheduleType[] {
+  return [...schedules].sort((a, b) => a.time.localeCompare(b.time));
+}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,9 +1,14 @@
 // 날짜 포맷: YYYY-MM-DD (로컬 기준)
-export const formatToDateString = (date: Date): string => date.toLocaleDateString("sv-SE");
+export const formatDateOnly = (date: Date): string => date.toLocaleDateString("sv-SE");
 
 // 날짜 포맷: YYYY-MM-DD (UTC 기준)
 export const formatToISOStringDate = (date: Date): string => date.toISOString().split("T")[0];
 
+export const formatTimeOnly = (date: Date): string => {
+  const h = date.getHours().toString().padStart(2, "0");
+  const m = date.getMinutes().toString().padStart(2, "0");
+  return `${h}:${m}`;
+};
 // 날짜 포맷: "2025년 5월 6일 월요일"
 export function formatToKoreanDate(date: Date): string {
   return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 ${getKoreanDayName(date.getDay())}`;


### PR DESCRIPTION
## 📌 작업 개요
- 일정 추가, 수정, 삭제 기능을 구현, localStorage를 통해 데이터가 유지되도록 연동

## ✨ 주요 변경 사항
- 일정 추가/수정 폼 구현 및 입력 값 유효성 검증
- 일정 수정 시 기존 값 로드 및 상태 반영 처리
- 일정 삭제 기능 구현
- localStorage에 일정 저장/불러오기 로직 작성
- 앱 초기 로딩 시 localStorage 데이터를 상태로 복원

## ✅ 체크리스트
- [x] 일정 추가 기능 정상 동작
- [x] 일정 수정 시 데이터 반영 확인
- [x] 삭제 시 localStorage 및 UI에서 모두 반영 확인
- [x] 새로고침해도 일정 데이터 유지됨 확인

## 🔗 관련 이슈
- 없음
