### PR TITLE
feat: 카테고리 추가/수정/삭제 기능 구현 및 일정 등록과 연동

### DIFF
--- a/src/components/AddCategoryModal.tsx
+++ b/src/components/AddCategoryModal.tsx
@@ -1,0 +1,104 @@
+import { useRef, useState } from "react";
+import { FaCheck } from "react-icons/fa";
+import { CategoryType } from "../types/category";
+import { useSetRecoilState } from "recoil";
+import { categoryState } from "../store/categoryAtom";
+
+const defaultCategoryColor = [
+  "bg-red-600",
+  "bg-red-400",
+  "bg-red-200",
+  "bg-pink-600",
+  "bg-pink-400",
+  "bg-pink-200",
+  "bg-orange-600",
+  "bg-orange-400",
+  "bg-orange-200",
+  "bg-yellow-600",
+  "bg-yellow-400",
+  "bg-yellow-200",
+  "bg-green-600",
+  "bg-green-400",
+  "bg-green-200",
+  "bg-teal-600",
+  "bg-teal-400",
+  "bg-teal-200",
+  "bg-blue-600",
+  "bg-blue-400",
+  "bg-blue-200",
+  "bg-purple-600",
+  "bg-purple-400",
+  "bg-purple-200",
+];
+
+interface AddCategoryModalProps {
+  onClose: () => void;
+  onAdd: (newCategory: CategoryType) => void;
+}
+
+export default function AddCategoryModal({ onClose, onAdd }: AddCategoryModalProps) {
+  const [label, setLabel] = useState("");
+  const [color, setColor] = useState(defaultCategoryColor[0]);
+  const labelRef = useRef<HTMLInputElement>(null);
+  const setCategories = useSetRecoilState(categoryState);
+
+  const handleSave = () => {
+    if (!label.trim()) {
+      labelRef.current?.focus();
+      return;
+    }
+
+    const newCategory: CategoryType = {
+      id: crypto.randomUUID(),
+      label,
+      color,
+    };
+
+    setCategories((prev) => [...prev, newCategory]);
+    onAdd(newCategory);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-lg p-6 w-[90%]">
+        <h2 className="text-lg font-bold mb-4">카테고리 추가</h2>
+
+        <label className="block text-sm font-semibold mb-1">이름</label>
+        <input
+          type="text"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="카테고리 이름"
+          className="w-full border rounded px-3 py-2 mb-4 bg-white text-sm"
+          ref={labelRef}
+        />
+
+        <label className="block text-sm font-semibold mb-1">색상</label>
+        <div className="w-full border rounded px-3 py-2 mb-4 bg-white h-28 grid grid-cols-6 gap-1 overflow-auto">
+          {defaultCategoryColor.map((c) => (
+            <button
+              key={c}
+              className={`w-10 h-10 rounded-full ${c} flex justify-center items-center`}
+              onClick={() => setColor(c)}
+            >
+              {c === color && <FaCheck className="text-2xl text-white" />}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button className="px-4 py-2 border rounded text-sm" onClick={onClose}>
+            취소
+          </button>
+          <button
+            className="px-4 py-2 bg-black text-white rounded text-sm font-bold"
+            onClick={handleSave}
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AddCategoryModal.tsx
+++ b/src/components/AddCategoryModal.tsx
@@ -1,42 +1,20 @@
 import { useRef, useState } from "react";
 import { FaCheck } from "react-icons/fa";
 import { CategoryType } from "../types/category";
-import { useSetRecoilState } from "recoil";
-import { categoryState } from "../store/categoryAtom";
-
-const defaultCategoryColor = [
-  "bg-red-600",
-  "bg-red-400",
-  "bg-red-200",
-  "bg-pink-600",
-  "bg-pink-400",
-  "bg-pink-200",
-  "bg-orange-600",
-  "bg-orange-400",
-  "bg-orange-200",
-  "bg-yellow-600",
-  "bg-yellow-400",
-  "bg-yellow-200",
-  "bg-green-600",
-  "bg-green-400",
-  "bg-green-200",
-  "bg-teal-600",
-  "bg-teal-400",
-  "bg-teal-200",
-  "bg-blue-600",
-  "bg-blue-400",
-  "bg-blue-200",
-  "bg-purple-600",
-  "bg-purple-400",
-  "bg-purple-200",
-];
+import { SetterOrUpdater, useSetRecoilState } from "recoil";
+import { categoryState, defaultCategoryColor } from "../store/categoryAtom";
 
 interface AddCategoryModalProps {
   onClose: () => void;
-  onAdd: (newCategory: CategoryType) => void;
+  onAddCategory?: (newCategory: CategoryType) => void;
+  setCategory?: SetterOrUpdater<CategoryType[]>;
 }
 
-export default function AddCategoryModal({ onClose, onAdd }: AddCategoryModalProps) {
+export default function AddCategoryModal({
+  onClose,
+  onAddCategory,
+  setCategory,
+}: AddCategoryModalProps) {
   const [label, setLabel] = useState("");
   const [color, setColor] = useState(defaultCategoryColor[0]);
   const labelRef = useRef<HTMLInputElement>(null);
@@ -53,9 +31,14 @@ export default function AddCategoryModal({ onClose, onAdd }: AddCategoryModalPro
       label,
       color,
     };
+    if (setCategory != null) {
+      setCategory((prev) => [...prev, newCategory]);
+    } else {
+      setCategories((prev) => [...prev, newCategory]);
+    }
 
-    setCategories((prev) => [...prev, newCategory]);
-    onAdd(newCategory);
+    if (onAddCategory != null) onAddCategory(newCategory);
+
     onClose();
   };
 

--- a/src/components/ColorPickerPopover.tsx
+++ b/src/components/ColorPickerPopover.tsx
@@ -1,0 +1,52 @@
+// components/ColorPickerPopover.tsx
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { defaultCategoryColor } from "../store/categoryAtom";
+import { FaCheck } from "react-icons/fa";
+import { useClickOutside } from "../hooks/useClickOutside";
+
+interface ColorPickerPopoverProps {
+  position: { top: number; left: number };
+  selectedColor: string;
+  onSelect: (color: string) => void;
+  onClose: () => void;
+}
+
+export default function ColorPickerPopover({
+  position,
+  selectedColor,
+  onSelect,
+  onClose,
+}: ColorPickerPopoverProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  useClickOutside(ref, onClose);
+
+  // Smart positioning: adjust if near bottom of screen
+  const popoverHeight = 200; // Approximate height in px
+  const viewportHeight = window.innerHeight - 50;
+  const adjustedTop =
+    position.top + popoverHeight > viewportHeight ? position.top - popoverHeight : position.top;
+
+  return createPortal(
+    <div
+      ref={ref}
+      className="absolute z-50 bg-white border rounded-lg shadow-md p-3 grid grid-cols-6 gap-2"
+      style={{ top: adjustedTop, left: position.left }}
+    >
+      {defaultCategoryColor.map((color) => (
+        <div
+          key={color}
+          className={`w-8 h-8 rounded-full cursor-pointer relative ${color}`}
+          onClick={() => onSelect(color)}
+        >
+          {selectedColor === color && (
+            <div className="absolute inset-0 flex items-center justify-center">
+              <FaCheck className="text-lg text-white" />
+            </div>
+          )}
+        </div>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/LogBox.tsx
+++ b/src/components/LogBox.tsx
@@ -8,7 +8,7 @@ export default function LogBox({ scheduleId }: { scheduleId: string }) {
 
   return (
     <ContentBox>
-      {retrospect ? (
+      {retrospect && (retrospect.content || retrospect.tags) ? (
         <Link to="/retrospect" state={{ scheduleId }}>
           <Log content={retrospect.content} tags={retrospect.tags} />
         </Link>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,23 +1,30 @@
 import clsx from "clsx";
 import { useNavigate } from "react-router-dom";
+import { IoChevronBack } from "react-icons/io5";
+import { JSX } from "react";
 
 interface PageHeaderProps {
   title: string;
   isTimer?: boolean;
+  rightSlot?: JSX.Element;
 }
 
-export default function PageHeader({ title, isTimer = false }: PageHeaderProps) {
+export default function PageHeader({ title, isTimer = false, rightSlot }: PageHeaderProps) {
   const navigate = useNavigate();
 
   return (
     <div className="fixed top-0 left-6 right-6">
       <header
-        className={clsx("py-4 flex relative", isTimer ? "text-white bg-neutral-900" : "bg-white")}
+        className={clsx(
+          "py-4 flex relative items-center justify-between",
+          isTimer ? "text-white bg-neutral-900" : "bg-white",
+        )}
       >
         <button onClick={() => navigate(-1)} className="text-2xl">
-          ←
+          <IoChevronBack />
         </button>
         <h1 className="absolute left-1/2 transform -translate-x-1/2 text-xl font-bold">{title}</h1>
+        {rightSlot}
       </header>
     </div>
   );

--- a/src/pages/LayoutWithoutFooter/CategoryManagePage.tsx
+++ b/src/pages/LayoutWithoutFooter/CategoryManagePage.tsx
@@ -1,0 +1,142 @@
+import { useRecoilState } from "recoil";
+import PageHeader from "../../components/PageHeader";
+import { categoryState } from "../../store/categoryAtom";
+import { FiTrash2, FiPlus } from "react-icons/fi";
+import { useState } from "react";
+import AddCategoryModal from "../../components/AddCategoryModal";
+import { useNavigate } from "react-router-dom";
+import ColorPickerPopover from "../../components/ColorPickerPopover";
+
+export default function CategoryManagePage() {
+  const navigate = useNavigate();
+  const [categories, setCategories] = useRecoilState(categoryState);
+  const [fixedCategory, setFixedCategory] = useState(categories);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editedLabel, setEditedLabel] = useState("");
+  const [showAddCategoryModal, setShowAddCategoryModal] = useState(false);
+  const [popoverPos, setPopoverPos] = useState({ top: 0, left: 0 });
+  const [showColorPicker, setShowColorPicker] = useState(false);
+
+  const handleSave = () => {
+    setCategories(fixedCategory);
+    navigate(-1);
+  };
+
+  const handleDelete = (id: string) => {
+    setFixedCategory((prev) => prev.filter((c) => c.id !== id));
+  };
+
+  const handleEdit = (id: string, label: string) => {
+    setEditingId(id);
+    setEditedLabel(label);
+  };
+
+  const handleSaveEdit = () => {
+    setFixedCategory((prev) =>
+      prev.map((cat) =>
+        cat.id === editingId ? { ...cat, label: editedLabel.trim() || cat.label } : cat,
+      ),
+    );
+    setEditingId(null);
+    setEditedLabel("");
+  };
+
+  const handleEnter = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleSaveEdit();
+    }
+  };
+
+  const handleOpenPicker = (e: React.MouseEvent, id: string) => {
+    const rect = (e.target as HTMLElement).getBoundingClientRect();
+    setEditingId(id);
+    setPopoverPos({ top: rect.bottom + window.scrollY + 4, left: rect.left + window.scrollX });
+    setShowColorPicker(true);
+  };
+
+  const handleSaveColorEdit = (color: string) => {
+    setFixedCategory((prev) =>
+      prev.map((cat) => (cat.id === editingId ? { ...cat, color: color } : cat)),
+    );
+    setEditingId(null);
+    setShowColorPicker(false);
+  };
+
+  return (
+    <div>
+      <PageHeader
+        title="카테고리 관리"
+        rightSlot={
+          <button onClick={() => setShowAddCategoryModal(true)} className="text-2xl">
+            <FiPlus />
+          </button>
+        }
+      />
+      <section className="mt-20">
+        <ul>
+          {fixedCategory.map((cat) => (
+            <li key={cat.id}>
+              <div className="flex items-center justify-between py-3 h-14">
+                <div className="flex items-center gap-3 flex-1 mr-3">
+                  <span
+                    className={`w-6 h-6 rounded-full ${cat.color}`}
+                    onClick={(e) => handleOpenPicker(e, cat.id)}
+                  />
+                  {showColorPicker && editingId === cat.id && (
+                    <ColorPickerPopover
+                      position={popoverPos}
+                      selectedColor={cat.color}
+                      onSelect={(newColor) => {
+                        handleSaveColorEdit(newColor);
+                      }}
+                      onClose={() => setShowColorPicker(false)}
+                    />
+                  )}
+                  {!showColorPicker && editingId === cat.id ? (
+                    <input
+                      className="flex-1 border rounded px-2 py-1 bg-white"
+                      value={editedLabel}
+                      onChange={(e) => setEditedLabel(e.target.value)}
+                      onBlur={handleSaveEdit}
+                      onKeyDown={(e) => handleEnter(e)}
+                      autoFocus
+                    />
+                  ) : (
+                    <span className="flex-1" onClick={() => handleEdit(cat.id, cat.label)}>
+                      {cat.label}
+                    </span>
+                  )}
+                </div>
+                <button
+                  onClick={() => {
+                    handleDelete(cat.id);
+                  }}
+                  className="text-gray-500"
+                >
+                  <FiTrash2 />
+                </button>
+              </div>
+              <hr />
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <div className="fixed bottom-0 left-0 right-0 w-full bg-white">
+        <button
+          className="m-6 w-[90%] py-3 bg-black font-bold text-white rounded-lg shadow-lg"
+          onClick={handleSave}
+        >
+          저장
+        </button>
+      </div>
+
+      {showAddCategoryModal && (
+        <AddCategoryModal
+          onClose={() => setShowAddCategoryModal(false)}
+          setCategory={(categories) => setFixedCategory(categories)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
+++ b/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
@@ -110,19 +110,21 @@ export default function RetrospectWritePage() {
       </section>
 
       {/* 저장 버튼 */}
-      <div className="fixed w-[90%] bottom-6 left-1/2 -translate-x-1/2 flex gap-1">
-        <button
-          className="w-1/2 border py-3 rounded-lg border-gray-400 bg-black font-bold text-white"
-          onClick={handleSave}
-        >
-          저장
-        </button>
-        <button
-          className="w-1/2 border py-3 rounded-lg border-red-400 text-red-400 font-bold"
-          onClick={handleDelete}
-        >
-          삭제
-        </button>
+      <div className="fixed bottom-0 left-0 right-0 w-full bg-white">
+        <div className="flex gap-1 m-6 font-bold">
+          <button
+            className="w-1/2 border py-3 rounded-lg border-gray-400 bg-black text-white"
+            onClick={handleSave}
+          >
+            저장
+          </button>
+          <button
+            className="w-1/2 border py-3 rounded-lg border-red-400 text-red-400"
+            onClick={handleDelete}
+          >
+            삭제
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
+++ b/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
@@ -121,7 +121,7 @@ export default function ScheduleFormPage() {
         <div className="relative w-full" ref={dropdownRef}>
           <label className="block mb-1 text-lg font-bold">카테고리</label>
           <button
-            onClick={() => setDropdownOpen(!open)}
+            onClick={() => setDropdownOpen(!dropdownOpen)}
             className="w-full flex items-center justify-between border p-2 rounded"
           >
             <div className="flex items-center gap-2">
@@ -132,7 +132,7 @@ export default function ScheduleFormPage() {
           </button>
 
           {dropdownOpen && (
-            <div className="absolute z-10 w-full border rounded shadow bg-white">
+            <div className="absolute z-10 w-full h-48 border rounded shadow bg-white overflow-auto">
               {categories.map((c) => (
                 <div
                   key={c.id}

--- a/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
+++ b/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
@@ -25,13 +25,13 @@ export default function ScheduleFormPage() {
     state?.selectedDate ? new Date(state.selectedDate) : new Date(),
   );
   const [category, setCategory] = useState<CategoryType>(categories[0]);
-  const [open, setOpen] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
   const [showCategoryModal, setShowCategoryModal] = useState(false);
 
   const setSchedules = useSetRecoilState(scheduleState);
 
-  useClickOutside(dropdownRef, () => setOpen(false), open);
+  useClickOutside(dropdownRef, () => setDropdownOpen(false), dropdownOpen);
 
   useEffect(() => {
     if (schedule) {
@@ -77,11 +77,11 @@ export default function ScheduleFormPage() {
 
   const handleChangeCategory = (category: CategoryType) => {
     setCategory(category);
-    setOpen(false);
+    setDropdownOpen(false);
   };
 
   const handleOpenAddCategory = () => {
-    setOpen(false);
+    setDropdownOpen(false);
     setShowCategoryModal(true);
   };
 
@@ -121,17 +121,17 @@ export default function ScheduleFormPage() {
         <div className="relative w-full" ref={dropdownRef}>
           <label className="block mb-1 text-lg font-bold">카테고리</label>
           <button
-            onClick={() => setOpen(!open)}
+            onClick={() => setDropdownOpen(!open)}
             className="w-full flex items-center justify-between border p-2 rounded"
           >
             <div className="flex items-center gap-2">
               <span className={`w-3 h-3 rounded-full ${category.color}`}></span>
               {category.label}
             </div>
-            <span>{open ? "▲" : "▼"}</span>
+            <span>{dropdownOpen ? "▲" : "▼"}</span>
           </button>
 
-          {open && (
+          {dropdownOpen && (
             <div className="absolute z-10 w-full border rounded shadow bg-white">
               {categories.map((c) => (
                 <div
@@ -190,7 +190,7 @@ export default function ScheduleFormPage() {
       )}
       {showCategoryModal && (
         <AddCategoryModal
-          onAdd={(newCategory) => {
+          onAddCategory={(newCategory) => {
             setCategory(newCategory);
           }}
           onClose={() => setShowCategoryModal(false)}

--- a/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
+++ b/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
@@ -11,13 +11,13 @@ import { ScheduleType } from "../../types/schedule";
 import { formatDateOnly, formatTimeOnly } from "../../utils/dateUtils";
 import { scheduleState } from "../../store/scheduleAtom";
 import { scheduleByIdSelector } from "../../store/scheduleSelector";
+import AddCategoryModal from "../../components/AddCategoryModal";
 
 export default function ScheduleFormPage() {
   const navigate = useNavigate();
   const { state } = useLocation();
   const schedule = useRecoilValue(scheduleByIdSelector(state?.scheduleId));
   const categories = useRecoilValue(categorySelector);
-  const [fixMode, setFixMode] = useState(true);
   const [title, setTitle] = useState("");
   const titleRef = useRef<HTMLInputElement>(null);
   const [memo, setMemo] = useState("");
@@ -27,6 +27,7 @@ export default function ScheduleFormPage() {
   const [category, setCategory] = useState<CategoryType>(categories[0]);
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef(null);
+  const [showCategoryModal, setShowCategoryModal] = useState(false);
 
   const setSchedules = useSetRecoilState(scheduleState);
 
@@ -34,7 +35,6 @@ export default function ScheduleFormPage() {
 
   useEffect(() => {
     if (schedule) {
-      setFixMode(false);
       setTitle(schedule.title);
       setMemo(schedule.memo ?? "");
       setCategory(categories.find((c) => c.id === schedule.category) ?? categories[0]);
@@ -81,8 +81,8 @@ export default function ScheduleFormPage() {
   };
 
   const handleOpenAddCategory = () => {
-    alert("카테고리 추가 기능 연결 예정");
     setOpen(false);
+    setShowCategoryModal(true);
   };
 
   return (
@@ -99,7 +99,6 @@ export default function ScheduleFormPage() {
             onChange={(e) => setTitle(e.target.value)}
             placeholder="제목을 입력하세요."
             className="w-full p-2 border rounded bg-white"
-            disabled={!fixMode}
             ref={titleRef}
           ></input>
         </div>
@@ -115,7 +114,6 @@ export default function ScheduleFormPage() {
             dateFormat="yyyy.MM.dd (eee) HH:mm" // 원하는 포맷
             className="w-full p-2 border rounded bg-white"
             wrapperClassName="w-full"
-            disabled={!fixMode}
           />
         </div>
 
@@ -125,13 +123,12 @@ export default function ScheduleFormPage() {
           <button
             onClick={() => setOpen(!open)}
             className="w-full flex items-center justify-between border p-2 rounded"
-            disabled={!fixMode}
           >
             <div className="flex items-center gap-2">
               <span className={`w-3 h-3 rounded-full ${category.color}`}></span>
               {category.label}
             </div>
-            <span>{fixMode && (open ? "▲" : "▼")}</span>
+            <span>{open ? "▲" : "▼"}</span>
           </button>
 
           {open && (
@@ -142,7 +139,7 @@ export default function ScheduleFormPage() {
                   onClick={() => handleChangeCategory(c)}
                   className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer"
                 >
-                  <span className={`w-3 h-3 rounded-full ${c.color}`}></span>
+                  <span className={`w-3 h-3 rounded-full ${c.color}`} />
                   {c.label}
                 </div>
               ))}
@@ -165,11 +162,10 @@ export default function ScheduleFormPage() {
             onChange={(e) => setMemo(e.target.value)}
             placeholder="메모를 입력하세요."
             className="w-full p-2 border rounded h-32 resize-none bg-white"
-            disabled={!fixMode}
           />
         </div>
       </section>
-      {fixMode ? (
+      {!schedule ? (
         <button
           className="fixed bottom-6 left-1/2 transform -translate-x-1/2 w-[90%] py-3 bg-black font-bold text-white rounded-lg shadow-lg"
           onClick={handleSave}
@@ -179,10 +175,10 @@ export default function ScheduleFormPage() {
       ) : (
         <div className="fixed w-[90%] bottom-6 left-1/2 -translate-x-1/2 flex gap-1">
           <button
-            className="w-1/2 border py-3 rounded-lg border-gray-400 font-bold"
-            onClick={() => setFixMode(true)}
+            className="w-1/2 border py-3 rounded-lg border-gray-400 bg-black font-bold text-white"
+            onClick={handleSave}
           >
-            수정
+            저장
           </button>
           <button
             className="w-1/2 border py-3 rounded-lg border-red-400 text-red-400 font-bold"
@@ -191,6 +187,14 @@ export default function ScheduleFormPage() {
             삭제
           </button>
         </div>
+      )}
+      {showCategoryModal && (
+        <AddCategoryModal
+          onAdd={(newCategory) => {
+            setCategory(newCategory);
+          }}
+          onClose={() => setShowCategoryModal(false)}
+        />
       )}
     </div>
   );

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { FaFolder, FaTag, FaBullseye, FaTrash, FaUser } from "react-icons/fa";
 import UnderLine from "../components/common/UnderLine";
+import { Link } from "react-router-dom";
 
 export default function MyPage() {
   const [targetHour, setTargetHour] = useState(7);
@@ -20,10 +21,12 @@ export default function MyPage() {
       <UnderLine />
 
       <ul className="space-y-4 text-[1.05rem] mt-6">
-        <li className="flex items-center gap-3">
-          <FaFolder className="text-lg" />
-          카테고리 관리
-        </li>
+        <Link to="/category">
+          <li className="flex items-center gap-3">
+            <FaFolder className="text-lg" />
+            카테고리 관리
+          </li>
+        </Link>
         <li className="flex items-center gap-3">
           <FaTag className="text-lg" />
           태그 관리

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -8,6 +8,7 @@ import ScheduleFormPage from "../pages/LayoutWithoutFooter/ScheduleFormPage";
 import LayoutWithoutFooter from "./LayoutWithoutFooter";
 import RetrospectWritePage from "../pages/LayoutWithoutFooter/RetrospectWritePage";
 import TimerPage from "../pages/LayoutWithoutFooter/TimerPage";
+import CategoryManagePage from "../pages/LayoutWithoutFooter/CategoryManagePage";
 
 export default function Router() {
   return (
@@ -22,6 +23,7 @@ export default function Router() {
       <Route element={<LayoutWithoutFooter />}>
         <Route path="/schedule-form" element={<ScheduleFormPage />} />
         <Route path="/retrospect" element={<RetrospectWritePage />} />
+        <Route path="/category" element={<CategoryManagePage />} />
       </Route>
 
       <Route path="/timer" element={<TimerPage />} />

--- a/src/store/categoryAtom.ts
+++ b/src/store/categoryAtom.ts
@@ -5,9 +5,36 @@ import { localStorageEffect } from "./utils/localStorageEffect";
 const CATEGORY_KEY = "focuslog_categories";
 
 const defaultCategories: CategoryType[] = [
-  { id: "1", label: "Study", color: "bg-blue-500" },
-  { id: "2", label: "Exercise", color: "bg-green-500" },
-  { id: "3", label: "Meeting", color: "bg-purple-500" },
+  { id: "1", label: "Study", color: "bg-blue-600" },
+  { id: "2", label: "Exercise", color: "bg-green-600" },
+  { id: "3", label: "Meeting", color: "bg-purple-600" },
+];
+
+export const defaultCategoryColor = [
+  "bg-red-600",
+  "bg-red-400",
+  "bg-red-200",
+  "bg-pink-600",
+  "bg-pink-400",
+  "bg-pink-200",
+  "bg-orange-600",
+  "bg-orange-400",
+  "bg-orange-200",
+  "bg-yellow-600",
+  "bg-yellow-400",
+  "bg-yellow-200",
+  "bg-green-600",
+  "bg-green-400",
+  "bg-green-200",
+  "bg-teal-600",
+  "bg-teal-400",
+  "bg-teal-200",
+  "bg-blue-600",
+  "bg-blue-400",
+  "bg-blue-200",
+  "bg-purple-600",
+  "bg-purple-400",
+  "bg-purple-200",
 ];
 
 export const categoryState = atom<CategoryType[]>({

--- a/src/store/categorySelector.ts
+++ b/src/store/categorySelector.ts
@@ -17,6 +17,6 @@ export const categoryByIdSelector = selectorFamily<CategoryType, string | undefi
     ({ get }) => {
       const categories = get(categoryState);
       const data = categories.find((cat) => cat.id === categoryId);
-      return data ?? { id: "", label: "", color: "gray-500" };
+      return data ?? { id: "", label: "", color: "bg-gray-400" };
     },
 });


### PR DESCRIPTION
## 📌 작업 개요
- 카테고리 관리 기능을 구현, 일정 등록 시 카테고리를 추가할 수 있도록 구현

## ✨ 주요 변경 사항

### 📅 일정 추가 화면
- 일정 추가 시 카테고리 추가 기능
- 카테고리 목록이 없을 경우 직접 추가 가능 (모달 등 활용)

### ⚙️ 마이페이지 - 카테고리 관리
- 카테고리 목록 확인 UI 구현
- 카테고리 추가/수정/삭제 기능 구현
- 삭제 시 해당 카테고리를 사용하는 일정 처리 방안 고려(회색컬러로 표시)

## ✅ 체크리스트
- [x] 일정 등록 시 카테고리 선택 및 추가 가능
- [x] 마이페이지에서 카테고리 CRUD 동작 정상
- [x] 카테고리 변경 시 UI 및 상태 반영 정상
- [x] localStorage 연동 확인

## 🔗 관련 이슈
- 없음
