### PR TITLE
feature: 마이페이지 - 목표시간세팅, 데이터 초기화 기능

### DIFF
--- a/src/features/Home/FocusSummary.tsx
+++ b/src/features/Home/FocusSummary.tsx
@@ -2,19 +2,20 @@ import { useRecoilValue } from "recoil";
 import ContentBox from "../../components/common/ContentBox";
 import { todayTotalFocusTimeSelector } from "../../store/retrospectSelector";
 import { formatKoreanDuration } from "../../utils/formatDuration";
+import { targetHourAtom } from "../../store/targetHourAtom";
 
 export default function FocusSummary() {
   const todayTotalFocusTime = useRecoilValue(todayTotalFocusTimeSelector);
+  const targetHour = useRecoilValue(targetHourAtom);
 
-  const maxTime = 3;
-  const percent = Math.floor((todayTotalFocusTime / (maxTime * 60 * 60)) * 100);
+  const percent = Math.floor((todayTotalFocusTime / (targetHour * 60 * 60)) * 100);
 
   return (
     <section className="my-8">
       <h2 className="text-xl font-bold mb-2">집중 요약</h2>
       <ContentBox>
         <p className="flex justify-between">
-          목표 시간 <span className="font-bold">{maxTime}시간</span>
+          목표 시간 <span className="font-bold">{targetHour}시간</span>
         </p>
         <p className="flex justify-between">
           완료 시간{" "}

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,10 +1,39 @@
-import { useState } from "react";
 import { FaFolder, FaTag, FaBullseye, FaTrash, FaUser } from "react-icons/fa";
 import UnderLine from "../components/common/UnderLine";
 import { Link } from "react-router-dom";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
+import { targetHourAtom } from "../store/targetHourAtom";
+import { FiPlus, FiMinus } from "react-icons/fi";
+import { scheduleState } from "../store/scheduleAtom";
+import { categoryState } from "../store/categoryAtom";
+import { tagState } from "../store/tagAtom";
+import { retrospectState } from "../store/retrospectAtom";
+import { initializeCategoryState, initializeTagState } from "../store/initializeRecoilDefaults";
 
 export default function MyPage() {
-  const [targetHour, setTargetHour] = useState(7);
+  const resetSchedule = useResetRecoilState(scheduleState);
+  const resetRetrospect = useResetRecoilState(retrospectState);
+  const resetCategory = useResetRecoilState(categoryState);
+  const resetTag = useResetRecoilState(tagState);
+  const resetTargetHour = useResetRecoilState(targetHourAtom);
+
+  const setCategory = useSetRecoilState(categoryState);
+  const setTag = useSetRecoilState(tagState);
+  const [targetHour, setTargetHour] = useRecoilState(targetHourAtom);
+
+  const handleResetAll = () => {
+    if (!confirm("모든 데이터를 초기화하시겠습니까?")) return;
+
+    resetSchedule();
+    resetCategory();
+    resetTag();
+    resetRetrospect();
+    resetTargetHour();
+    localStorage.clear();
+
+    initializeCategoryState(setCategory);
+    initializeTagState(setTag);
+  };
 
   return (
     <div>
@@ -42,9 +71,28 @@ export default function MyPage() {
             <FaBullseye className="text-lg" />
             목표 집중시간 설정
           </div>
-          <span className="text-gray-700">{targetHour}h</span>
+          <span className="text-gray-700 flex items-center gap-2">
+            <button
+              className="border p-1 rounded"
+              onClick={() => {
+                setTargetHour((prev) => (prev > 1 ? --prev : prev));
+              }}
+            >
+              <FiMinus />
+            </button>
+            {targetHour}시간
+            <button
+              className="border p-1 rounded"
+              onClick={() => {
+                setTargetHour((prev) => (prev < 24 ? ++prev : prev));
+              }}
+            >
+              <FiPlus />
+            </button>
+          </span>
         </li>
-        <li className="flex items-center gap-3">
+
+        <li className="flex items-center gap-3" onClick={handleResetAll}>
           <FaTrash className="text-lg" />
           모든 데이터 초기화
         </li>

--- a/src/store/categoryAtom.ts
+++ b/src/store/categoryAtom.ts
@@ -1,14 +1,9 @@
 import { atom } from "recoil";
 import { CategoryType } from "../types/category";
 import { localStorageEffect } from "./utils/localStorageEffect";
+import { defaultCategories } from "./initializeRecoilDefaults";
 
 const CATEGORY_KEY = "focuslog_categories";
-
-const defaultCategories: CategoryType[] = [
-  { id: "1", label: "Study", color: "bg-blue-600" },
-  { id: "2", label: "Exercise", color: "bg-green-600" },
-  { id: "3", label: "Meeting", color: "bg-purple-600" },
-];
 
 export const defaultCategoryColor = [
   "bg-red-600",

--- a/src/store/initializeRecoilDefaults.ts
+++ b/src/store/initializeRecoilDefaults.ts
@@ -1,0 +1,18 @@
+import { SetterOrUpdater } from "recoil";
+import { CategoryType } from "../types/category";
+
+export const defaultCategories: CategoryType[] = [
+  { id: "1", label: "Study", color: "bg-blue-600" },
+  { id: "2", label: "Exercise", color: "bg-green-600" },
+  { id: "3", label: "Meeting", color: "bg-purple-600" },
+];
+
+export const defaultTags: string[] = ["집중됨", "뿌듯함", "힘듦", "피곤함"];
+
+export const initializeCategoryState = (set: SetterOrUpdater<CategoryType[]>) => {
+  set(defaultCategories);
+};
+
+export const initializeTagState = (set: SetterOrUpdater<string[]>) => {
+  set(defaultTags);
+};

--- a/src/store/tagAtom.ts
+++ b/src/store/tagAtom.ts
@@ -1,9 +1,8 @@
 import { atom } from "recoil";
 import { localStorageEffect } from "./utils/localStorageEffect";
+import { defaultTags } from "./initializeRecoilDefaults";
 
 const TAG_KEY = "focuslog_tags";
-
-const defaultTags: string[] = ["집중됨", "뿌듯함", "힘듦", "피곤함"];
 
 export const tagState = atom<string[]>({
   key: "tagState",

--- a/src/store/targetHourAtom.ts
+++ b/src/store/targetHourAtom.ts
@@ -1,0 +1,15 @@
+import { atom } from "recoil";
+
+export const targetHourAtom = atom<number>({
+  key: "targetHourAtom",
+  default: 5,
+  effects_UNSTABLE: [
+    ({ setSelf, onSet }) => {
+      const saved = localStorage.getItem("targetHour");
+      if (saved) setSelf(Number(saved));
+      onSet((newVal) => {
+        localStorage.setItem("targetHour", newVal.toString());
+      });
+    },
+  ],
+});


### PR DESCRIPTION
## 📌 작업 개요
- 마이페이지에서 사용자가 목표 집중 시간을 설정, 전체 데이터를 초기화할 수 있는 기능을 구현

## ✨ 주요 변경 사항

### ⏱️ 목표시간 설정
- 증감버튼을 통해 1시간에서 24시간까지 세팅가능
- 설정된 값은 localStorage에 저장
- 추후 통계 화면 또는 타이머 초기 상태에 반영 가능

### ♻️ 데이터 초기화
- localStorage에 저장된 일정, 회고, 카테고리, 태그 등의 전체 데이터 초기화 버튼 추가
- 확인 모달을 통해 사용자 동작 방지
- 초기화 시 설정된 목표 시간 외 모든 데이터 제거

## ✅ 체크리스트
- [x] 목표 시간 설정 후 저장 시 반영 확인
- [x] 새로고침 후 목표 시간 유지 확인
- [x] 초기화 버튼 클릭 시 데이터 모두 삭제됨 확인
- [x] 확인 모달 정상 작동

## 🔗 관련 이슈
- 없음