### PR TITLE
feat: 통계 페이지 구현 및 카테고리 필터 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^18.2.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.2",
+        "react-select": "^5.10.1",
         "recoil": "^0.7.7"
       },
       "devDependencies": {
@@ -69,7 +70,6 @@
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
       "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
@@ -122,7 +122,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
       "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.27.0",
         "@babel/types": "^7.27.0",
@@ -154,7 +153,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
       "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
-      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -193,7 +191,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
       "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -202,7 +199,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -233,7 +229,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
       "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.27.0"
       },
@@ -274,11 +269,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
       "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "@babel/parser": "^7.27.0",
@@ -292,7 +294,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
       "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "@babel/generator": "^7.27.0",
@@ -310,7 +311,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -319,7 +319,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
       "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -327,6 +326,114 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.3",
@@ -998,7 +1105,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1012,7 +1118,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1021,7 +1126,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1029,14 +1133,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1689,11 +1791,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+    },
     "node_modules/@types/react": {
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1705,6 +1811,14 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2240,6 +2354,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2363,7 +2491,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2527,6 +2654,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2566,8 +2716,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/daisyui": {
       "version": "2.52.0",
@@ -2653,7 +2802,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2739,6 +2887,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2783,6 +2940,19 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/es-abstract": {
       "version": "1.23.9",
@@ -3003,7 +3173,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -3449,6 +3618,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3546,7 +3720,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3835,12 +4008,19 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/ignore": {
@@ -3856,7 +4036,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -3992,7 +4171,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -4346,7 +4524,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -4359,6 +4536,11 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4664,8 +4846,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4716,6 +4897,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4772,8 +4958,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -4838,7 +5023,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5032,12 +5216,28 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -5061,8 +5261,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -5086,11 +5285,18 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -5314,7 +5520,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -5398,8 +5603,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5445,6 +5649,41 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-select": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.1.tgz",
+      "integrity": "sha512-roPEZUL4aRZDx6DcsD+ZNreVl+fM8VsKn0Wtex1v4IazH60ILp5xhdlp464IsEAlJdXeD+BhDAFsBVMfvLQueA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-cache": {
@@ -5533,7 +5772,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -5553,7 +5791,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5864,6 +6101,14 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6083,6 +6328,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -6121,7 +6371,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6509,6 +6758,19 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
+      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.2",
+    "react-select": "^5.10.1",
     "recoil": "^0.7.7"
   },
   "devDependencies": {

--- a/src/components/common/BaseSelect.tsx
+++ b/src/components/common/BaseSelect.tsx
@@ -1,0 +1,41 @@
+import Select, { SingleValue } from "react-select";
+import { baseSelectStyles } from "../../styles/selectStyles";
+
+interface BaseOption<T> {
+  value: T;
+  label: string;
+}
+
+interface BaseSelectProps<T> {
+  value: T;
+  onChange: (value: T) => void;
+  options: BaseOption<T>[];
+  placeholder?: string;
+}
+
+export default function BaseSelect<T>({
+  value,
+  onChange,
+  options,
+  placeholder,
+}: BaseSelectProps<T>) {
+  const selectedOption = options.find((o) => o.value === value);
+
+  const handleChange = (selected: SingleValue<BaseOption<T>>) => {
+    if (selected) {
+      onChange(selected.value);
+    }
+  };
+
+  return (
+    <Select
+      value={selectedOption}
+      onChange={handleChange}
+      options={options}
+      styles={baseSelectStyles}
+      isSearchable={false}
+      placeholder={placeholder}
+      menuPlacement="auto"
+    />
+  );
+}

--- a/src/components/features/statistics/CategorySelect.tsx
+++ b/src/components/features/statistics/CategorySelect.tsx
@@ -1,0 +1,24 @@
+import { CategoryType } from "../../../features";
+import BaseSelect from "../../common/BaseSelect";
+
+interface CategoryOption {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  category: string;
+  setCategory: (value: string) => void;
+  categories: CategoryType[];
+}
+
+const CategorySelect = ({ category, setCategory, categories }: Props) => {
+  const options: CategoryOption[] = [
+    { value: "all", label: "카테고리 전체" },
+    ...categories.map((c) => ({ value: c.id, label: c.label })),
+  ];
+
+  return <BaseSelect value={category} onChange={setCategory} options={options} />;
+};
+
+export default CategorySelect;

--- a/src/components/features/statistics/FocusTimeByWeekday.tsx
+++ b/src/components/features/statistics/FocusTimeByWeekday.tsx
@@ -1,0 +1,38 @@
+import { useRecoilValue } from "recoil";
+import { retrospectState } from "../../../features";
+import { DateRange, filterRetrospectsByDateRange } from "../../../utils/date/dateRangeFilter";
+
+const dayLabels = ["일", "월", "화", "수", "목", "금", "토"];
+interface FocusTimeByDayProps {
+  period: DateRange;
+}
+export default function FocusTimeByDay({ period }: FocusTimeByDayProps) {
+  const retrospects = useRecoilValue(retrospectState);
+  const filtered = filterRetrospectsByDateRange(retrospects, period);
+  const focusTimeByDay = Array(dayLabels.length).fill(0);
+
+  filtered.forEach((r) => {
+    const date = new Date(r.date);
+    const day = date.getDay();
+    focusTimeByDay[day] += r.focusDuration || 0;
+  });
+
+  const max = Math.max(...focusTimeByDay, 1);
+
+  return (
+    <div className="my-4">
+      <h2 className="font-bold mb-2">요일별 집중 시간</h2>
+      <div className="flex justify-between items-end h-32 px-6">
+        {focusTimeByDay.map((v, i) => (
+          <div key={i} className="h-full flex flex-col items-center justify-end">
+            <div
+              className={`w-4 rounded-t ${v === max ? "bg-sky-400" : "bg-gray-400"}`}
+              style={{ height: `${(v / max) * 100}%` }}
+            ></div>
+            <span className="text-sm mt-1">{dayLabels[i]}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/statistics/FocusTimeByWeekday.tsx
+++ b/src/components/features/statistics/FocusTimeByWeekday.tsx
@@ -1,14 +1,16 @@
 import { useRecoilValue } from "recoil";
 import { retrospectState } from "../../../features";
-import { DateRange, filterRetrospectsByDateRange } from "../../../utils/date/dateRangeFilter";
+import { DateRange } from "../../../utils/date/dateRangeFilter";
+import { filterRetrospects } from "../../../utils/filter/filterRetrospects";
 
 const dayLabels = ["일", "월", "화", "수", "목", "금", "토"];
 interface FocusTimeByDayProps {
   period: DateRange;
+  category: string;
 }
-export default function FocusTimeByDay({ period }: FocusTimeByDayProps) {
+export default function FocusTimeByDay({ period, category }: FocusTimeByDayProps) {
   const retrospects = useRecoilValue(retrospectState);
-  const filtered = filterRetrospectsByDateRange(retrospects, period);
+  const filtered = filterRetrospects(retrospects, period, category);
   const focusTimeByDay = Array(dayLabels.length).fill(0);
 
   filtered.forEach((r) => {

--- a/src/components/features/statistics/PeriodSelect.tsx
+++ b/src/components/features/statistics/PeriodSelect.tsx
@@ -1,0 +1,24 @@
+import { DateRange } from "../../../utils/date/dateRangeFilter";
+import BaseSelect from "../../common/BaseSelect";
+
+interface PeriodOption {
+  value: DateRange;
+  label: string;
+}
+
+interface Props {
+  period: DateRange;
+  setPeriod: (value: DateRange) => void;
+}
+
+const PeriodSelect = ({ period, setPeriod }: Props) => {
+  const options: PeriodOption[] = [
+    { value: "1week", label: "최근 1주" },
+    { value: "1month", label: "최근 1개월" },
+    { value: "1year", label: "최근 1년" },
+  ];
+
+  return <BaseSelect value={period} onChange={setPeriod} options={options} />;
+};
+
+export default PeriodSelect;

--- a/src/components/features/statistics/RetrospectCompletionRate.tsx
+++ b/src/components/features/statistics/RetrospectCompletionRate.tsx
@@ -3,26 +3,32 @@ import ContentBox from "../../common/ContentBox";
 import Log from "../../Log";
 import { useRecoilValue } from "recoil";
 import { retrospectState, scheduleState } from "../../../features";
-import {
-  DateRange,
-  filterRetrospectsByDateRange,
-  filterSchedulesByDateRange,
-} from "../../../utils/date/dateRangeFilter";
+import { DateRange } from "../../../utils/date/dateRangeFilter";
+import { filterSchedules } from "../../../utils/filter/filterSchedules";
+import { filterRetrospects } from "../../../utils/filter/filterRetrospects";
 
 interface RetrospectCompletionRateProps {
   period: DateRange;
+  category: string;
 }
 
-export default function RetrospectCompletionRate({ period }: RetrospectCompletionRateProps) {
+export default function RetrospectCompletionRate({
+  period,
+  category,
+}: RetrospectCompletionRateProps) {
   const [showIndex, setShowIndex] = useState(-1);
   const schedules = useRecoilValue(scheduleState);
-  const filteredSchedules = filterSchedulesByDateRange(schedules, period);
+  const filteredSchedules = filterSchedules(schedules, period, category);
   const retrospects = useRecoilValue(retrospectState);
-  const filteredRetrospects = filterRetrospectsByDateRange(
+  const filteredRetrospects = filterRetrospects(
     retrospects.filter((r) => r.content || r.tags),
     period,
+    category,
   );
-  const completionRate = (filteredRetrospects.length / filteredSchedules.length) * 100;
+  const completionRate =
+    filteredSchedules.length === 0
+      ? 0
+      : (filteredRetrospects.length / filteredSchedules.length) * 100;
   const circumference = 2 * Math.PI * 16; // 반지름 r = 16
   const offset = circumference - (circumference * completionRate) / 100;
 

--- a/src/components/features/statistics/RetrospectCompletionRate.tsx
+++ b/src/components/features/statistics/RetrospectCompletionRate.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import ContentBox from "../../common/ContentBox";
+import Log from "../../Log";
+import { useRecoilValue } from "recoil";
+import { retrospectState, scheduleState } from "../../../features";
+import {
+  DateRange,
+  filterRetrospectsByDateRange,
+  filterSchedulesByDateRange,
+} from "../../../utils/date/dateRangeFilter";
+
+interface RetrospectCompletionRateProps {
+  period: DateRange;
+}
+
+export default function RetrospectCompletionRate({ period }: RetrospectCompletionRateProps) {
+  const [showIndex, setShowIndex] = useState(-1);
+  const schedules = useRecoilValue(scheduleState);
+  const filteredSchedules = filterSchedulesByDateRange(schedules, period);
+  const retrospects = useRecoilValue(retrospectState);
+  const filteredRetrospects = filterRetrospectsByDateRange(
+    retrospects.filter((r) => r.content || r.tags),
+    period,
+  );
+  const completionRate = (filteredRetrospects.length / filteredSchedules.length) * 100;
+  const circumference = 2 * Math.PI * 16; // 반지름 r = 16
+  const offset = circumference - (circumference * completionRate) / 100;
+
+  useEffect(() => {
+    setShowIndex(Math.floor(Math.random() * filteredRetrospects.length));
+  }, []);
+
+  return (
+    <div className="mb-4">
+      <p className="font-bold mb-2">회고 작성률</p>
+      <ContentBox>
+        <div className="flex items-center gap-3">
+          <div className="relative w-16 h-16 shrink-0">
+            <svg viewBox="0 0 36 36" className="w-full h-full">
+              <circle cx="18" cy="18" r="16" fill="none" stroke="#eee" strokeWidth="4" />
+              <circle
+                cx="18"
+                cy="18"
+                r="16"
+                fill="none"
+                stroke="#facc15"
+                strokeWidth="4"
+                strokeDasharray={circumference}
+                strokeDashoffset={offset}
+                strokeLinecap="round"
+                transform="rotate(-90 18 18)"
+              />
+            </svg>
+            <div className="absolute inset-0 flex items-center justify-center text-sm font-bold">
+              {completionRate}%
+            </div>
+          </div>
+          {filteredRetrospects.length > 0 ? (
+            <Log
+              content={filteredRetrospects[showIndex]?.content}
+              tags={filteredRetrospects[showIndex]?.tags}
+            />
+          ) : (
+            <div>
+              <p className="text-m">작성된 회고가 없습니다.</p>
+              <p className="text-sm">* 회고는 타이머 완료 후 작성할 수 있어요.</p>
+            </div>
+          )}
+        </div>
+      </ContentBox>
+    </div>
+  );
+}

--- a/src/components/features/statistics/TagStatistics.tsx
+++ b/src/components/features/statistics/TagStatistics.tsx
@@ -1,17 +1,19 @@
 import { useRecoilValue } from "recoil";
 import { retrospectState } from "../../../features";
-import { DateRange, filterRetrospectsByDateRange } from "../../../utils/date/dateRangeFilter";
+import { DateRange } from "../../../utils/date/dateRangeFilter";
+import { filterRetrospects } from "../../../utils/filter/filterRetrospects";
 
 type tagCount = Record<string, number>;
 const showCount = 5;
 
 interface TagStatisticsProps {
   period: DateRange;
+  category: string;
 }
 
-export default function TagStatistics({ period }: TagStatisticsProps) {
+export default function TagStatistics({ period, category }: TagStatisticsProps) {
   const retrospects = useRecoilValue(retrospectState);
-  const filtered = filterRetrospectsByDateRange(retrospects, period);
+  const filtered = filterRetrospects(retrospects, period, category);
 
   const tagCounts: tagCount = {};
   filtered.forEach((r) => {

--- a/src/components/features/statistics/TagStatistics.tsx
+++ b/src/components/features/statistics/TagStatistics.tsx
@@ -1,0 +1,46 @@
+import { useRecoilValue } from "recoil";
+import { retrospectState } from "../../../features";
+import { DateRange, filterRetrospectsByDateRange } from "../../../utils/date/dateRangeFilter";
+
+type tagCount = Record<string, number>;
+const showCount = 5;
+
+interface TagStatisticsProps {
+  period: DateRange;
+}
+
+export default function TagStatistics({ period }: TagStatisticsProps) {
+  const retrospects = useRecoilValue(retrospectState);
+  const filtered = filterRetrospectsByDateRange(retrospects, period);
+
+  const tagCounts: tagCount = {};
+  filtered.forEach((r) => {
+    r.tags?.forEach((tag: string) => {
+      tagCounts[tag] = (tagCounts[tag] || 0) + 1;
+    });
+  });
+  const maxCount = Math.max(...Object.values(tagCounts), 1);
+
+  const topTags = Object.entries(tagCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, showCount);
+
+  return (
+    <div className="mb-4">
+      <h2 className="font-bold mb-2">감정 태그 통계</h2>
+      <div className="flex flex-col gap-2">
+        {topTags.map(([tag, count]) => (
+          <div key={tag} className="flex items-center gap-2">
+            <span className="w-20">#{tag}</span>
+            <div className="flex-1 bg-gray-200 h-3 rounded-full">
+              <div
+                className={`h-full rounded-full ${count === maxCount ? "bg-yellow-400" : "bg-gray-400"}`}
+                style={{ width: `${(count / filtered.length) * 100}%` }}
+              ></div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/statistics/TotalFocusTime.tsx
+++ b/src/components/features/statistics/TotalFocusTime.tsx
@@ -1,15 +1,17 @@
 import { useRecoilValue } from "recoil";
 import { retrospectState } from "../../../features";
 import { formatKoreanDuration } from "../../../utils/date/formatDuration";
-import { DateRange, filterRetrospectsByDateRange } from "../../../utils/date/dateRangeFilter";
+import { DateRange } from "../../../utils/date/dateRangeFilter";
+import { filterRetrospects } from "../../../utils/filter/filterRetrospects";
 
 interface FocusTimeByWeekdayProps {
   period: DateRange;
+  category: string;
 }
 
-export default function FocusTimeByWeekday({ period }: FocusTimeByWeekdayProps) {
+export default function FocusTimeByWeekday({ period, category }: FocusTimeByWeekdayProps) {
   const retrospects = useRecoilValue(retrospectState);
-  const filtered = filterRetrospectsByDateRange(retrospects, period);
+  const filtered = filterRetrospects(retrospects, period, category);
   const todayTotalFocusTime = filtered.reduce((sum, r) => sum + (r.focusDuration || 0), 0);
 
   return (

--- a/src/components/features/statistics/TotalFocusTime.tsx
+++ b/src/components/features/statistics/TotalFocusTime.tsx
@@ -1,0 +1,23 @@
+import { useRecoilValue } from "recoil";
+import { retrospectState } from "../../../features";
+import { formatKoreanDuration } from "../../../utils/date/formatDuration";
+import { DateRange, filterRetrospectsByDateRange } from "../../../utils/date/dateRangeFilter";
+
+interface FocusTimeByWeekdayProps {
+  period: DateRange;
+}
+
+export default function FocusTimeByWeekday({ period }: FocusTimeByWeekdayProps) {
+  const retrospects = useRecoilValue(retrospectState);
+  const filtered = filterRetrospectsByDateRange(retrospects, period);
+  const todayTotalFocusTime = filtered.reduce((sum, r) => sum + (r.focusDuration || 0), 0);
+
+  return (
+    <div className="my-4 flex justify-between items-center">
+      <h2 className="font-bold">총 집중 시간</h2>
+      <p className="text-2xl font-bold">
+        <span className="text-2xl">{formatKoreanDuration(todayTotalFocusTime)}</span>
+      </p>
+    </div>
+  );
+}

--- a/src/features/retrospect/types.ts
+++ b/src/features/retrospect/types.ts
@@ -4,5 +4,6 @@ export interface RetrospectType {
   date: string;
   focusDuration: number;
   content: string;
+  category: string;
   tags?: string[];
 }

--- a/src/features/retrospect/types.ts
+++ b/src/features/retrospect/types.ts
@@ -1,6 +1,7 @@
 export interface RetrospectType {
   id: string;
   scheduleId: string;
+  date: string;
   focusDuration: number;
   content: string;
   tags?: string[];

--- a/src/index.css
+++ b/src/index.css
@@ -4,17 +4,8 @@
 
 :root {
   font-family:
-    "Pretendard",
-    -apple-system,
-    BlinkMacSystemFont,
-    system-ui,
-    Roboto,
-    "Helvetica Neue",
-    "Segoe UI",
-    "Apple SD Gothic Neo",
-    "Noto Sans KR",
-    "Malgun Gothic",
-    sans-serif;
+    -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI",
+    "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
+++ b/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
@@ -7,16 +7,18 @@ import {
   retrospectState,
   RetrospectType,
   retrospectByScheduleIdSelector,
+  scheduleByIdSelector,
 } from "../../features";
 import PageHeader from "../../components/PageHeader";
 import Schedule from "../../components/Schedule";
 import AddTagModal from "../../components/modals/AddTagModal";
+import { formatDateOnly } from "../../utils/date/dateUtils";
 
 export default function RetrospectWritePage() {
   const navigate = useNavigate();
   const { state } = useLocation();
   const scheduleId = state?.scheduleId;
-
+  const schedule = useRecoilValue(scheduleByIdSelector(scheduleId));
   const retrospect = useRecoilValue(retrospectByScheduleIdSelector(scheduleId));
   const setRetrospect = useSetRecoilState(retrospectState);
   const allTags = useRecoilValue(tagState);
@@ -51,6 +53,7 @@ export default function RetrospectWritePage() {
     const newRetrospect: RetrospectType = {
       id: retrospect.id,
       scheduleId,
+      date: schedule ? schedule.date : formatDateOnly(new Date()),
       focusDuration: retrospect.focusDuration,
       content: note,
       tags,

--- a/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
+++ b/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
@@ -56,6 +56,7 @@ export default function RetrospectWritePage() {
       date: schedule ? schedule.date : formatDateOnly(new Date()),
       focusDuration: retrospect.focusDuration,
       content: note,
+      category: schedule ? schedule.category : "",
       tags,
     };
 

--- a/src/pages/LayoutWithoutFooter/TimerPage.tsx
+++ b/src/pages/LayoutWithoutFooter/TimerPage.tsx
@@ -2,8 +2,9 @@ import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import PageHeader from "../../components/PageHeader";
 import Schedule from "../../components/Schedule";
-import { useSetRecoilState } from "recoil";
-import { retrospectState, RetrospectType } from "../../features";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { retrospectState, RetrospectType, scheduleByIdSelector } from "../../features";
+import { formatDateOnly } from "../../utils/date/dateUtils";
 
 enum TimerStatus {
   READY = "READY",
@@ -16,6 +17,7 @@ export default function TimerPage() {
   const scheduleId = state?.scheduleId;
   const navigate = useNavigate();
 
+  const schedule = useRecoilValue(scheduleByIdSelector(scheduleId));
   const setRetrospect = useSetRecoilState(retrospectState);
   const [status, setStatus] = useState<TimerStatus>(TimerStatus.READY);
   const [time, setTime] = useState(0);
@@ -65,6 +67,7 @@ export default function TimerPage() {
     const newRetrospect: RetrospectType = {
       id: crypto.randomUUID(),
       scheduleId,
+      date: schedule ? schedule.date : formatDateOnly(new Date()),
       focusDuration,
       content: "",
     };

--- a/src/pages/LayoutWithoutFooter/TimerPage.tsx
+++ b/src/pages/LayoutWithoutFooter/TimerPage.tsx
@@ -69,6 +69,7 @@ export default function TimerPage() {
       scheduleId,
       date: schedule ? schedule.date : formatDateOnly(new Date()),
       focusDuration,
+      category: schedule ? schedule.category : "",
       content: "",
     };
 

--- a/src/pages/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage.tsx
@@ -5,9 +5,14 @@ import FocusTimeByWeekday from "../components/features/statistics/FocusTimeByWee
 import TagStatistics from "../components/features/statistics/TagStatistics";
 import RetrospectCompletionRate from "../components/features/statistics/RetrospectCompletionRate";
 import { DateRange } from "../utils/date/dateRangeFilter";
+import { useRecoilValue } from "recoil";
+import { categoryState } from "../features";
+import CategorySelect from "../components/features/statistics/CategorySelect";
+import PeriodSelect from "../components/features/statistics/PeriodSelect";
 
 export default function StatisticsPage() {
   const [period, setPeriod] = useState<DateRange>("1week");
+  const categories = useRecoilValue(categoryState);
   const [category, setCategory] = useState("all");
 
   return (
@@ -15,37 +20,29 @@ export default function StatisticsPage() {
       <header className="py-4 text-xl font-bold text-center">통계</header>
 
       <div className="flex gap-2 mb-4">
-        <select
-          className="border rounded p-2 flex-1 bg-white"
-          value={period}
-          onChange={(e) => setPeriod(e.target.value as DateRange)}
-        >
-          <option value="1week">최근 1주</option>
-          <option value="1month">최근 1개월</option>
-          <option value="1year">최근 1년</option>
-        </select>
-        <select
-          className="border rounded p-2 flex-1 bg-white"
-          value={category}
-          onChange={(e) => setCategory(e.target.value)}
-        >
-          <option value="all">카테고리 전체</option>
-          <option value="study">Study</option>
-          <option value="meeting">Meeting</option>
-        </select>
+        <div className="flex-1">
+          <PeriodSelect period={period} setPeriod={(e) => setPeriod(e)} />
+        </div>
+        <div className="flex-1">
+          <CategorySelect
+            category={category}
+            setCategory={(c) => setCategory(c)}
+            categories={categories}
+          />
+        </div>
       </div>
       <UnderLine />
 
-      <TotalFocusTime period={period} />
+      <TotalFocusTime period={period} category={category} />
       <hr className="my-4" />
 
-      <FocusTimeByWeekday period={period} />
+      <FocusTimeByWeekday period={period} category={category} />
       <hr className="my-4" />
 
-      <TagStatistics period={period} />
+      <TagStatistics period={period} category={category} />
       <hr className="my-4" />
 
-      <RetrospectCompletionRate period={period} />
+      <RetrospectCompletionRate period={period} category={category} />
     </div>
   );
 }

--- a/src/pages/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
 import UnderLine from "../components/common/UnderLine";
-import ContentBox from "../components/common/ContentBox";
-import Log from "../components/Log";
+import TotalFocusTime from "../components/features/statistics/TotalFocusTime";
+import FocusTimeByWeekday from "../components/features/statistics/FocusTimeByWeekday";
+import TagStatistics from "../components/features/statistics/TagStatistics";
+import RetrospectCompletionRate from "../components/features/statistics/RetrospectCompletionRate";
+import { DateRange } from "../utils/date/dateRangeFilter";
 
 export default function StatisticsPage() {
-  const [period, setPeriod] = useState("1week");
+  const [period, setPeriod] = useState<DateRange>("1week");
   const [category, setCategory] = useState("all");
 
   return (
@@ -15,10 +18,11 @@ export default function StatisticsPage() {
         <select
           className="border rounded p-2 flex-1 bg-white"
           value={period}
-          onChange={(e) => setPeriod(e.target.value)}
+          onChange={(e) => setPeriod(e.target.value as DateRange)}
         >
           <option value="1week">최근 1주</option>
           <option value="1month">최근 1개월</option>
+          <option value="1year">최근 1년</option>
         </select>
         <select
           className="border rounded p-2 flex-1 bg-white"
@@ -32,74 +36,16 @@ export default function StatisticsPage() {
       </div>
       <UnderLine />
 
-      <div className="my-4 flex justify-between items-center">
-        <h2 className="font-bold">총 집중 시간</h2>
-        <p className="text-2xl font-bold">
-          <span className="text-3xl">14시간</span> 30분
-        </p>
-      </div>
+      <TotalFocusTime period={period} />
       <hr className="my-4" />
 
-      <div className="my-4">
-        <h2 className="font-bold mb-2">요일별 집중 시간</h2>
-        <div className="flex justify-between items-end h-32 px-6">
-          {[1, 2, 3, 4, 5, 2, 1].map((v, i) => (
-            <div key={i} className="flex flex-col items-center">
-              <div
-                className={`w-4 rounded-t bg-${i === 2 ? "sky" : "gray"}-400`}
-                style={{ height: `${v * 10}px` }}
-              ></div>
-              <span className="text-sm mt-1">{"일월화수목금토"[i]}</span>
-            </div>
-          ))}
-        </div>
-      </div>
+      <FocusTimeByWeekday period={period} />
       <hr className="my-4" />
 
-      <div className="mb-4">
-        <h2 className="font-bold mb-2">감정 태그 통계</h2>
-        <div className="flex flex-col gap-2">
-          {["집중됨", "피곤함", "주의산만"].map((tag, i) => (
-            <div key={tag} className="flex items-center gap-2">
-              <span className="w-20">#{tag}</span>
-              <div className="flex-1 bg-gray-200 h-3 rounded-full">
-                <div
-                  className={`h-full rounded-full ${i === 0 ? "bg-yellow-300 w-[80%]" : i === 1 ? "bg-gray-400 w-[60%]" : "bg-gray-300 w-[30%]"}`}
-                ></div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
+      <TagStatistics period={period} />
       <hr className="my-4" />
 
-      <div className="mb-4">
-        <p className="font-bold mb-2">회고 작성률</p>
-        <ContentBox>
-          <div className="flex items-center gap-3">
-            <div className="relative w-16 h-16 shrink-0">
-              <svg viewBox="0 0 36 36" className="w-full h-full">
-                <circle cx="18" cy="18" r="16" fill="none" stroke="#eee" strokeWidth="4" />
-                <circle
-                  cx="18"
-                  cy="18"
-                  r="16"
-                  fill="none"
-                  stroke="#facc15"
-                  strokeWidth="4"
-                  strokeDasharray="113"
-                  strokeDashoffset="34"
-                  strokeLinecap="round"
-                />
-              </svg>
-              <div className="absolute inset-0 flex items-center justify-center text-sm font-bold">
-                70%
-              </div>
-            </div>
-            <Log />
-          </div>
-        </ContentBox>
-      </div>
+      <RetrospectCompletionRate period={period} />
     </div>
   );
 }

--- a/src/styles/selectStyles.ts
+++ b/src/styles/selectStyles.ts
@@ -1,0 +1,30 @@
+export const baseSelectStyles = {
+  control: (base: any) => ({
+    ...base,
+    fontSize: "0.875rem", // text-sm
+    backgroundColor: "#fff",
+    paddingLeft: "0.5rem",
+    paddingRight: "0.5rem",
+  }),
+  menu: (base: any) => ({
+    ...base,
+    boxShadow: "0 1px 3px rgba(0, 0, 0, 0.2)",
+    fontSize: "0.875rem",
+    zIndex: 20,
+  }),
+  option: (base: any, state: any) => ({
+    ...base,
+    backgroundColor: state.isSelected
+      ? "#eab308" // yellow-400
+      : "#fff",
+    color: "#000",
+    cursor: "pointer",
+    padding: "0.5rem 0.75rem",
+  }),
+  indicatorSeparator: () => ({ display: "none" }), // | 제거
+  dropdownIndicator: (base: any) => ({
+    ...base,
+    padding: "0 0.25rem",
+    color: "#9ca3af", // gray-400
+  }),
+};

--- a/src/utils/date/dateRangeFilter.ts
+++ b/src/utils/date/dateRangeFilter.ts
@@ -1,0 +1,40 @@
+import { RetrospectType, ScheduleType } from "../../features";
+
+export type DateRange = "1week" | "1month" | "1year";
+
+function getStartAndEndDate(range: DateRange) {
+  const today = new Date();
+  const startDate = new Date();
+
+  switch (range) {
+    case "1week":
+      startDate.setDate(today.getDate() - 6); // 오늘 포함 7일
+      break;
+    case "1month":
+      startDate.setMonth(today.getMonth() - 1);
+      break;
+    case "1year":
+      startDate.setFullYear(today.getFullYear() - 1);
+      break;
+  }
+
+  return { startDate, today };
+}
+
+export function filterRetrospectsByDateRange(retrospects: RetrospectType[], range: DateRange) {
+  const { startDate, today } = getStartAndEndDate(range);
+
+  return retrospects.filter((r) => {
+    const retrospectDate = new Date(`${r.date}T00:00:00`);
+    return retrospectDate >= startDate && retrospectDate <= today;
+  });
+}
+
+export function filterSchedulesByDateRange(schedules: ScheduleType[], range: DateRange) {
+  const { startDate, today } = getStartAndEndDate(range);
+
+  return schedules.filter((s) => {
+    const scheduleDate = new Date(`${s.date}T00:00:00`);
+    return scheduleDate >= startDate && scheduleDate <= today;
+  });
+}

--- a/src/utils/date/dateRangeFilter.ts
+++ b/src/utils/date/dateRangeFilter.ts
@@ -1,8 +1,6 @@
-import { RetrospectType, ScheduleType } from "../../features";
-
 export type DateRange = "1week" | "1month" | "1year";
 
-function getStartAndEndDate(range: DateRange) {
+export function getStartAndEndDate(range: DateRange) {
   const today = new Date();
   const startDate = new Date();
 
@@ -19,22 +17,4 @@ function getStartAndEndDate(range: DateRange) {
   }
 
   return { startDate, today };
-}
-
-export function filterRetrospectsByDateRange(retrospects: RetrospectType[], range: DateRange) {
-  const { startDate, today } = getStartAndEndDate(range);
-
-  return retrospects.filter((r) => {
-    const retrospectDate = new Date(`${r.date}T00:00:00`);
-    return retrospectDate >= startDate && retrospectDate <= today;
-  });
-}
-
-export function filterSchedulesByDateRange(schedules: ScheduleType[], range: DateRange) {
-  const { startDate, today } = getStartAndEndDate(range);
-
-  return schedules.filter((s) => {
-    const scheduleDate = new Date(`${s.date}T00:00:00`);
-    return scheduleDate >= startDate && scheduleDate <= today;
-  });
 }

--- a/src/utils/filter/filterRetrospects.ts
+++ b/src/utils/filter/filterRetrospects.ts
@@ -1,0 +1,18 @@
+import { RetrospectType } from "../../features";
+import { DateRange, getStartAndEndDate } from "../date/dateRangeFilter";
+
+export function filterRetrospects(
+  retrospects: RetrospectType[],
+  period: DateRange,
+  category: string, // 'all' or category.id
+) {
+  const { startDate, today } = getStartAndEndDate(period);
+
+  return retrospects.filter((r) => {
+    const date = new Date(`${r.date}T00:00:00`);
+    const inRange = date >= startDate && date <= today;
+    const categoryMatch = category === "all" || r.category === category;
+
+    return inRange && categoryMatch;
+  });
+}

--- a/src/utils/filter/filterSchedules.ts
+++ b/src/utils/filter/filterSchedules.ts
@@ -1,0 +1,18 @@
+import { ScheduleType } from "../../features";
+import { DateRange, getStartAndEndDate } from "../date/dateRangeFilter";
+
+export function filterSchedules(
+  schedules: ScheduleType[],
+  period: DateRange,
+  category: string, // 'all' or category.id
+) {
+  const { startDate, today } = getStartAndEndDate(period);
+
+  return schedules.filter((r) => {
+    const date = new Date(`${r.date}T00:00:00`);
+    const inRange = date >= startDate && date <= today;
+    const categoryMatch = category === "all" || r.category === category;
+
+    return inRange && categoryMatch;
+  });
+}


### PR DESCRIPTION
## 📌 작업 개요
- 사용자 집중/일정 데이터를 바탕으로 통계 페이지를 구현, 카테고리, 기간 필터를 통해 데이터를 조건별로 확인할 수 있도록 기능 확장

## ✨ 주요 변경 사항

### 📊 통계 페이지
- 통계 카드: 총 집중 시간, 회고 수 등 요약 정보 표시
- 일간 그래프: 날짜별 집중 시간 시각화
- 기간 필터: 최근 1주, 1개월, 1년 기준 필터링

### 🗂️ 카테고리 필터
- 통계 대상 데이터를 선택한 카테고리 기준으로 필터링
- 선택된 카테고리 외 데이터는 통계 계산 및 그래프 렌더링 제외
- 카테고리 선택 컴포넌트 UI 구현
- 카테고리 변경 시 상태 업데이트 및 통계 자동 반영

## ✅ 체크리스트
- [x] 통계 카드, 그래프 정상 렌더링
- [x] 기간 필터 기능 정상 동작
- [x] 카테고리 선택 시 통계 결과 변경됨
- [x] localStorage 기반 데이터 연동 확인 완료

## 🔗 관련 이슈
- 없음
