### PR TITLE
style: 모바일 전용 반응형 고정 및 PC 해상도 최대 너비 제한 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,11 @@ function App() {
   useInitializeAppData();
 
   return (
-    <BrowserRouter>
-      <Router />
-    </BrowserRouter>
+    <div className="mx-auto w-full max-w-lg">
+      <BrowserRouter>
+        <Router />
+      </BrowserRouter>
+    </div>
   );
 }
 

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -19,7 +19,7 @@ export default function PageHeader({
   const navigate = useNavigate();
 
   return (
-    <div className="fixed top-0 left-6 right-6">
+    <div className="max-w-md mx-auto fixed top-0 left-6 right-6">
       <header
         className={clsx(
           "py-4 flex relative items-center justify-between",

--- a/src/components/common/FormActionButtons.tsx
+++ b/src/components/common/FormActionButtons.tsx
@@ -4,7 +4,7 @@ interface FormActionButtonsProps {
 }
 export default function FormActionButtons({ onSave, onDelete }: FormActionButtonsProps) {
   return (
-    <div className="fixed w-[90%] bottom-6 left-1/2 -translate-x-1/2 flex gap-4 ">
+    <div className="max-w-md mx-auto fixed w-[90%] bottom-6 left-1/2 -translate-x-1/2 flex gap-4 ">
       <button
         className="w-1/2 border py-3.5 rounded-lg border-primary bg-primary font-bold text-white shadow-md hover:bg-primary/80 transition-all duration-200"
         onClick={onSave}

--- a/src/components/common/PrimaryButton.tsx
+++ b/src/components/common/PrimaryButton.tsx
@@ -11,7 +11,7 @@ export default function PrimaryButton({ onClick, children, className = "" }: Pri
   return (
     <button
       className={clsx(
-        "py-3.5 border-primary bg-primary font-bold text-white rounded-lg shadow-md hover:bg-primary/80 transition-all duration-200",
+        "max-w-md py-3.5 border-primary bg-primary font-bold text-white rounded-lg shadow-md hover:bg-primary/80 transition-all duration-200",
         className,
       )}
       onClick={onClick}

--- a/src/components/features/home/RetrospectBox.tsx
+++ b/src/components/features/home/RetrospectBox.tsx
@@ -29,7 +29,7 @@ export default function RetrospectBox() {
         회고 현황
         {filteredRetrospects.length > 0 && (
           <button
-            className="px-3 py-1 border border-gray-300 rounded-lg text-sm font-normal flex items-center"
+            className="px-3 py-1 border border-gray-300 rounded-lg text-sm font-normal flex items-center  hover:bg-primary/5 transition-all"
             onClick={handleChangeLog}
           >
             <LuRefreshCw className="mr-2" />

--- a/src/components/features/myPage/ManageItemList.tsx
+++ b/src/components/features/myPage/ManageItemList.tsx
@@ -45,7 +45,7 @@ export default function ManageItemList<T>({
 
                 {editingKey === key ? (
                   <input
-                    className="flex-1 border rounded px-2 py-1 bg-white"
+                    className="flex-1 border rounded px-2 py-1 bg-white focus:outline-none focus:ring-2 focus:ring-primary"
                     value={editedLabel}
                     onChange={(e) => setEditedLabel(e.target.value)}
                     onBlur={onSaveEdit}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,7 +4,7 @@ import { IoStatsChart } from "react-icons/io5";
 
 export default function Footer() {
   return (
-    <div className="btm-nav bg-white border-t-2 border-gray-200 h-24">
+    <div className="btm-nav bg-white border-t-2 border-gray-200 h-24 max-w-lg mx-auto">
       <NavLink
         to="/"
         className={({ isActive }) =>

--- a/src/components/modals/AddCategoryModal.tsx
+++ b/src/components/modals/AddCategoryModal.tsx
@@ -51,7 +51,7 @@ export default function AddCategoryModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-lg p-6 w-[90%]">
+      <div className="max-w-md mx-auto bg-white rounded-lg shadow-lg p-6 w-[90%]">
         <h2 className="text-lg font-bold mb-4">카테고리 추가</h2>
 
         <label className="block text-sm font-semibold mb-1">이름</label>

--- a/src/components/modals/AddTagModal.tsx
+++ b/src/components/modals/AddTagModal.tsx
@@ -43,7 +43,7 @@ export default function AddTagModal({ onClose, onAddTag, setTag }: AddTagModal) 
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-lg p-6 w-[90%]">
+      <div className="max-w-md mx-auto bg-white rounded-lg shadow-lg p-6 w-[90%]">
         <h2 className="text-lg font-bold mb-4">태그 추가</h2>
         <input
           type="text"

--- a/src/components/modals/ColorPickerPopover.tsx
+++ b/src/components/modals/ColorPickerPopover.tsx
@@ -20,8 +20,7 @@ export default function ColorPickerPopover({
   const ref = useRef<HTMLDivElement>(null);
   useClickOutside(ref, onClose);
 
-  // Smart positioning: adjust if near bottom of screen
-  const popoverHeight = 200; // Approximate height in px
+  const popoverHeight = 200;
   const viewportHeight = window.innerHeight - 50;
   const adjustedTop =
     position.top + popoverHeight > viewportHeight ? position.top - popoverHeight : position.top;
@@ -29,7 +28,7 @@ export default function ColorPickerPopover({
   return createPortal(
     <div
       ref={ref}
-      className="absolute z-50 bg-white border rounded-lg shadow-md p-3 grid grid-cols-6 gap-2"
+      className="absolute z-50 bg-white border border-primary rounded-lg shadow-md p-3 grid grid-cols-6 gap-2"
       style={{ top: adjustedTop, left: position.left }}
     >
       {defaultCategoryColor.map((color) => (

--- a/src/pages/LayoutWithoutFooter/CategoryManagePage.tsx
+++ b/src/pages/LayoutWithoutFooter/CategoryManagePage.tsx
@@ -110,7 +110,7 @@ export default function CategoryManagePage() {
         )}
       </section>
 
-      <div className="fixed bottom-0 left-0 right-0 w-full bg-white">
+      <div className="max-w-md mx-auto fixed bottom-0 left-0 right-0 w-full bg-white">
         <PrimaryButton onClick={handleSave} className="m-6 w-[90%]">
           저장
         </PrimaryButton>

--- a/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
+++ b/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
@@ -15,7 +15,7 @@ import { useAuthUser } from "@/hooks/useAuthUser";
 import { addSchedule, deleteSchedule, updateSchedule } from "@/firebase";
 import PrimaryButton from "@/components/common/PrimaryButton";
 import FormActionButtons from "@/components/common/FormActionButtons";
-import CategoryForm from "@/components/features/scheduleForm/categoryForm";
+import CategoryForm from "@/components/features/scheduleForm/CategoryForm";
 import DateForm from "@/components/features/scheduleForm/DateForm";
 
 export default function ScheduleFormPage() {

--- a/src/pages/LayoutWithoutFooter/TagManagePage.tsx
+++ b/src/pages/LayoutWithoutFooter/TagManagePage.tsx
@@ -69,7 +69,7 @@ export default function TagManagePage() {
         />
       </section>
 
-      <div className="fixed bottom-0 left-0 right-0 w-full bg-white">
+      <div className="max-w-md mx-auto fixed bottom-0 left-0 right-0 w-full bg-white">
         <PrimaryButton onClick={handleSave} className="m-6 w-[90%]">
           저장
         </PrimaryButton>

--- a/src/pages/LayoutWithoutFooter/TimerPage.tsx
+++ b/src/pages/LayoutWithoutFooter/TimerPage.tsx
@@ -99,8 +99,8 @@ export default function TimerPage() {
     <div className="h-screen bg-neutral-900 text-white px-6">
       <PageHeader title="Timer" isTimer={true} />
 
-      <section className="w-full pt-24">
-        <div className="w-full aspect-square flex flex-col  justify-center items-center">
+      <section className="pt-24 max-w-md mx-auto">
+        <div className="aspect-square flex flex-col justify-center items-center">
           <span
             className={`${status === TimerStatus.RUNNING ? "text-7xl" : "text-6xl"} font-extrabold tracking-widest`}
           >


### PR DESCRIPTION
## 📱 작업 개요
- FocusLog는 모바일 중심 앱으로, PC 화면에서는 레이아웃이 과도하게 늘어나는 문제 방지
- 모든 화면을 모바일 기준으로 고정하고, 가로 최대 너비 제한 적용

---

## ✨ 주요 변경 사항

### 🖼 레이아웃 조정
- 전체 앱 래퍼에 `max-w-md` 적용 (`w-full max-w-md mx-auto`)
- PC 해상도에서 가로 폭 고정 (예: 448px)
- 모든 화면 중앙 정렬되도록 `mx-auto` 및 `min-h-screen` 구조 적용

### 💅 스타일 보완
- 좌우 패딩, 마진 등 모바일 기준 여백 유지되도록 정리
- max-width 제한이 필요한 상위 컴포넌트 외부에도 적용

---

## ✅ 체크리스트

- [x] 모바일 해상도에서는 기존과 동일하게 출력
- [x] PC 해상도에서 가로폭이 제한되어 과도한 확장 없음
- [x] 모든 페이지에서 중앙 정렬 유지
- [x] 스타일/정렬 깨짐 없이 적용됨

---

## 🔗 관련 이슈
- PC에서 UI 좌우 너무 넓게 퍼지는 현상
