### PR TITLE
fix: Vercel 새로고침 시 SPA 라우팅 404 에러 해결

### DIFF
--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -16,18 +16,20 @@ export default function CalendarPage() {
   }, []);
 
   return (
-    <div className="w-full mt-2">
+    <div className="w-full mt-4">
       <Calendar selectedDate={selectedDate} onDateChange={setSelectedDate} />
       <UnderLine />
       <CalendarScheduleList selectedDate={selectedDate} />
-      <Link
-        to="/schedule-form"
-        state={{ selectedDate }}
-        className="fixed bottom-20 right-4 w-12 h-12 rounded-full bg-primary text-white shadow-lg flex items-center justify-center transition hover:bg-primary/80 hover:scale-110"
-        aria-label="일정 추가하기"
-      >
-        <FaPlusCircle className="text-3xl" />
-      </Link>
+      <div className="fixed bottom-24 max-w-md w-full flex justify-end">
+        <Link
+          to="/schedule-form"
+          state={{ selectedDate }}
+          className="w-14 h-14 rounded-full bg-primary text-white shadow-lg flex items-center justify-center transition hover:bg-primary/80 hover:scale-110"
+          aria-label="일정 추가하기"
+        >
+          <FaPlusCircle className="text-3xl" />
+        </Link>
+      </div>
     </div>
   );
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 
 export default defineConfig({
+  base: "/",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## 🐞 버그 개요

- 캘린더 일정추가하기 버튼 위치 수정
- Vite + React Router 기반 SPA를 Vercel에 배포한 후
- 클라이언트 라우팅 경로에서 새로고침하면 404 에러가 발생하는 이슈

---

## 🔍 원인

- Vercel은 기본적으로 `/statistics`, `/mypage` 등 경로 접근 시
  해당하는 정적 HTML 파일을 찾으려 함
- 하지만 Vite SPA에서는 오직 `index.html`만 존재하고,
  나머지 경로는 클라이언트 라우터(React Router)가 처리함
- 따라서 새로고침 시 서버에서 경로를 인식하지 못해 404 발생

---

## ✅ 해결 방법

- 프로젝트 루트에 `vercel.json` 파일 추가
- 모든 요청을 `/index.html`로 리라이트 처리하여 React Router가 처리하도록 설정

```json
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/index.html" }
  ]
}
