### PR TITLE
feat: 캘린더 월/년도 선택 모달 추가 및 시각적 개선

### DIFF
--- a/src/components/features/calendar/Calendar.tsx
+++ b/src/components/features/calendar/Calendar.tsx
@@ -115,8 +115,9 @@ export default function Calendar({ selectedDate, onDateChange }: CalendarProps) 
               <div
                 key={idx}
                 className="w-full flex flex-col items-center justify-center cursor-pointer"
+                onClick={() => onDateChange(date)}
               >
-                <div className={`${opacity} mb-1`} onClick={() => onDateChange(date)}>
+                <div className={`${opacity} mb-1`}>
                   <div
                     className={`w-6 h-6 text-sm flex items-center justify-center ${
                       isSelected ? "bg-primary text-white font-bold rounded-full" : ""

--- a/src/components/features/calendar/Calendar.tsx
+++ b/src/components/features/calendar/Calendar.tsx
@@ -1,6 +1,9 @@
 import { useRecoilValue } from "recoil";
 import { getSchedulesByMonthSelector, categorySelector } from "@/recoil";
 import { formatDateOnly } from "../../../utils/date/dateUtils";
+import { FaAngleDown } from "react-icons/fa";
+import CalendarModal from "@/components/modals/CalendarModal";
+import { useState } from "react";
 
 interface CalendarProps {
   selectedDate: Date;
@@ -8,27 +11,28 @@ interface CalendarProps {
 }
 
 export default function Calendar({ selectedDate, onDateChange }: CalendarProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedYear, setSelectedYear] = useState(selectedDate.getFullYear());
+  const [selectedMonth, setSelectedMonth] = useState(selectedDate.getMonth());
+
   const monthSchedules = useRecoilValue(getSchedulesByMonthSelector(selectedDate));
   const categories = useRecoilValue(categorySelector);
 
-  const year = selectedDate.getFullYear();
-  const month = selectedDate.getMonth();
-
   // 달의 첫째 날 (ex: 2025-04-01)
-  const firstDay = new Date(year, month, 1);
+  const firstDay = new Date(selectedYear, selectedMonth, 1);
   const firstDayOfWeek = firstDay.getDay(); // 요일 (0=일, 1=월, ..., 6=토)
 
   // 이달이 며칠까지 있는지
-  const lastDate = new Date(year, month + 1, 0).getDate();
+  const lastDate = new Date(selectedYear, selectedMonth + 1, 0).getDate();
 
   // 날짜 배열 만들기 (빈칸 포함)
   const dates: { date: Date; isCurrentMonth: boolean }[] = [];
 
-  const prevMonthLastDate = new Date(year, month, 0).getDate();
+  const prevMonthLastDate = new Date(selectedYear, selectedMonth, 0).getDate();
   // 앞에 빈칸 (ex: 1일이 수요일이면 앞에 0,0)
   for (let i = 0; i < firstDayOfWeek; i++) {
     dates.unshift({
-      date: new Date(year, month - 1, prevMonthLastDate - i),
+      date: new Date(selectedYear, selectedMonth - 1, prevMonthLastDate - i),
       isCurrentMonth: false,
     });
   }
@@ -36,7 +40,7 @@ export default function Calendar({ selectedDate, onDateChange }: CalendarProps) 
   // 날짜 채우기
   for (let i = 1; i <= lastDate; i++) {
     dates.push({
-      date: new Date(year, month, i),
+      date: new Date(selectedYear, selectedMonth, i),
       isCurrentMonth: true,
     });
   }
@@ -45,7 +49,7 @@ export default function Calendar({ selectedDate, onDateChange }: CalendarProps) 
   while (dates.length < 42) {
     const nextDay = dates.length - (firstDayOfWeek + lastDate) + 1;
     dates.push({
-      date: new Date(year, month + 1, nextDay),
+      date: new Date(selectedYear, selectedMonth + 1, nextDay),
       isCurrentMonth: false,
     });
   }
@@ -55,10 +59,35 @@ export default function Calendar({ selectedDate, onDateChange }: CalendarProps) 
     d1.getMonth() === d2.getMonth() &&
     d1.getDate() === d2.getDate();
 
+  const handleChangeYearMonth = (y: number, m: number) => {
+    setSelectedMonth(m);
+    setSelectedYear(y);
+  };
+
   return (
     <div>
       {/* 년/월 표시 */}
-      <div className="text-lg font-bold mb-3 tracking-tight">{`${year}년 ${month + 1}월`}</div>
+      <div className="relative inline-block">
+        <button
+          className="text-lg font-bold mb-3 tracking-tight flex items-center"
+          onClick={() => {
+            console.log("open");
+            setIsOpen(true);
+          }}
+        >
+          {`${selectedYear}년 ${selectedMonth + 1}월`}
+          <FaAngleDown className="ml-1" />
+        </button>
+        {isOpen && (
+          <CalendarModal
+            year={selectedYear}
+            month={selectedMonth + 1}
+            isOpen={isOpen}
+            onOpen={setIsOpen}
+            onSelect={handleChangeYearMonth}
+          />
+        )}
+      </div>
 
       <div className="mx-[-0.8rem]">
         {/* 요일 표시 */}
@@ -83,7 +112,10 @@ export default function Calendar({ selectedDate, onDateChange }: CalendarProps) 
             const schedules = monthSchedules.filter((s) => s.date === formatDateOnly(date));
 
             return (
-              <div key={idx} className="w-full flex flex-col items-center justify-center">
+              <div
+                key={idx}
+                className="w-full flex flex-col items-center justify-center cursor-pointer"
+              >
                 <div className={`${opacity} mb-1`} onClick={() => onDateChange(date)}>
                   <div
                     className={`w-6 h-6 text-sm flex items-center justify-center ${
@@ -93,7 +125,7 @@ export default function Calendar({ selectedDate, onDateChange }: CalendarProps) 
                     {date.getDate()}
                   </div>
                 </div>
-                <div className="flex gap-1 mb-2">
+                <div className="flex gap-1 mb-2 min-h-[0.25rem]">
                   {schedules.map((s) => {
                     const color = categories.find((e) => e.id === s.category);
 

--- a/src/components/modals/CalendarModal.tsx
+++ b/src/components/modals/CalendarModal.tsx
@@ -1,0 +1,64 @@
+import { motion } from "framer-motion";
+import { useClickOutside } from "@/hooks/useClickOutside";
+import { useRef, useState } from "react";
+
+interface CalendarModalProps {
+  year: number;
+  month: number;
+  isOpen: boolean;
+  onOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onSelect: (y: number, m: number) => void;
+}
+export default function CalendarModal({
+  year,
+  month,
+  isOpen,
+  onOpen,
+  onSelect,
+}: CalendarModalProps) {
+  const openRef = useRef(null);
+  const [selectedYear, setSelectedYear] = useState(year);
+
+  useClickOutside(openRef, () => onOpen(false), isOpen);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.2 }}
+    >
+      <div
+        className="absolute ring-1 ring-gray-300 z-50 w-52 bg-white rounded-lg shadow-md p-3"
+        ref={openRef}
+      >
+        <div className="flex justify-between items-center mb-2">
+          <button onClick={() => setSelectedYear((prev) => --prev)}>◀</button>
+          <span>{selectedYear}년</span>
+          <button onClick={() => setSelectedYear((prev) => ++prev)}>▶</button>
+        </div>
+
+        <div className="grid grid-cols-4 gap-2 text-sm">
+          {Array.from({ length: 12 }).map((_, i) => {
+            const m = i + 1;
+            return (
+              <button
+                key={m}
+                className={`py-2 rounded ${
+                  month === m && year === selectedYear
+                    ? "bg-primary text-white"
+                    : "hover:bg-gray-100"
+                }`}
+                onClick={() => {
+                  onSelect(selectedYear, m - 1);
+                  onOpen(false);
+                }}
+              >
+                {m}월
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
### 주요 변경 사항
- 월/년도 선택 가능한 모달 UI 구현
- 현재 월 강조 및 클릭 시 달력 상태 갱신 처리
- 외부 클릭 시 모달 닫힘 처리 적용
- framer-motion 기반 팝업 애니메이션 적용
- 테두리, 그림자, z-index 조정으로 가시성 개선

### 테스트
- 캘린더 헤더 클릭 → 월/년도 선택 → 달력 정상 업데이트 확인
- 외부 클릭 → 모달 닫힘 정상 작동 확인
- 테마 및 배경 대비로 모달 시인성 확보 확인