### PR TITLE
태그 및 회고 글자수 제한 추가 + 카테고리 삭제 이슈 수정

### DIFF
--- a/src/components/common/AlertPopup.tsx
+++ b/src/components/common/AlertPopup.tsx
@@ -25,7 +25,7 @@ export default function AlertPopup({
           exit={{ opacity: 0 }}
         >
           <motion.div
-            className="bg-white rounded-lg shadow-xl p-6 w-[60%] max-w-sm text-center"
+            className="bg-white rounded-lg shadow-xl p-6 w-[80%] max-w-sm text-center"
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}

--- a/src/components/features/calendar/Calendar.tsx
+++ b/src/components/features/calendar/Calendar.tsx
@@ -131,7 +131,10 @@ export default function Calendar({ selectedDate, onDateChange }: CalendarProps) 
                     const color = categories.find((e) => e.id === s.category);
 
                     return (
-                      <span key={s.id} className={`w-1 h-1 rounded-full ${color?.color}`}></span>
+                      <span
+                        key={s.id}
+                        className={`w-1 h-1 rounded-full ${color ? color.color : "bg-gray-400"}`}
+                      ></span>
                     );
                   })}
                 </div>

--- a/src/components/features/scheduleForm/CategoryForm.tsx
+++ b/src/components/features/scheduleForm/CategoryForm.tsx
@@ -5,8 +5,8 @@ import { useRef, useState } from "react";
 
 interface CategoryFormProps {
   categories: CategoryType[];
-  selectedCategory: CategoryType;
-  setSelectedCategory: React.Dispatch<React.SetStateAction<CategoryType>>;
+  selectedCategory: CategoryType | null;
+  setSelectedCategory: React.Dispatch<React.SetStateAction<CategoryType | null>>;
 }
 
 export default function CategoryForm({
@@ -39,8 +39,8 @@ export default function CategoryForm({
           className={`w-full flex items-center justify-between border py-2 px-4 rounded mb-1 ${dropdownOpen && "focus:ring-1 focus:ring-primary"}`}
         >
           <div className="flex items-center gap-2 text-sm">
-            <span className={`w-3 h-3 rounded-full ${selectedCategory.color}`}></span>
-            {selectedCategory.label}
+            <span className={`w-3 h-3 rounded-full ${selectedCategory?.color}`}></span>
+            {selectedCategory?.label}
           </div>
           <span className="text-sm">{dropdownOpen ? "▲" : "▼"}</span>
         </button>
@@ -51,7 +51,7 @@ export default function CategoryForm({
               <div
                 key={c.id}
                 onClick={() => handleChangeCategory(c)}
-                className={`flex items-center text-sm gap-2 px-4 py-2 ${selectedCategory.id === c.id ? "bg-primary/80 text-white" : "hover:bg-primary/10"} cursor-pointer`}
+                className={`flex items-center text-sm gap-2 px-4 py-2 ${selectedCategory?.id === c.id ? "bg-primary/80 text-white" : "hover:bg-primary/10"} cursor-pointer`}
               >
                 <span className={`w-3 h-3 rounded-full ${c.color}`} />
                 {c.label}

--- a/src/components/modals/AddTagModal.tsx
+++ b/src/components/modals/AddTagModal.tsx
@@ -18,6 +18,7 @@ export default function AddTagModal({ onClose, onAddTag, setTag }: AddTagModal) 
   const [label, setLabel] = useState("");
   const labelRef = useRef<HTMLInputElement>(null);
   const [tags, setTags] = useRecoilState(tagState);
+  const maxLabel = 10;
 
   const handleSave = async () => {
     if (!label.trim()) {
@@ -45,6 +46,17 @@ export default function AddTagModal({ onClose, onAddTag, setTag }: AddTagModal) 
     onClose();
   };
 
+  const handleChangeLabel = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const labels = e.target.value.split(",").map((t) => t.trim());
+    if (labels.length > 0 && labels.some((l) => l.length > maxLabel)) {
+      toast.error(`${maxLabel}자를 넘는 태그는 추가할 수 없어요.`);
+
+      return;
+    }
+
+    setLabel(e.target.value);
+  };
+
   return (
     <AnimatePresence>
       <motion.div
@@ -54,7 +66,7 @@ export default function AddTagModal({ onClose, onAddTag, setTag }: AddTagModal) 
         exit={{ opacity: 0 }}
       >
         <motion.div
-          className="bg-white rounded-lg shadow-xl p-6 w-[70%] max-w-sm"
+          className="bg-white rounded-lg shadow-xl p-6 w-[80%] max-w-sm"
           initial={{ scale: 0.9, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
           exit={{ scale: 0.9, opacity: 0 }}
@@ -64,7 +76,7 @@ export default function AddTagModal({ onClose, onAddTag, setTag }: AddTagModal) 
           <input
             type="text"
             value={label}
-            onChange={(e) => setLabel(e.target.value)}
+            onChange={handleChangeLabel}
             placeholder="뿌듯함, 피곤함"
             className="w-full border rounded px-3 py-2 mb-1 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-primary"
             ref={labelRef}
@@ -73,7 +85,10 @@ export default function AddTagModal({ onClose, onAddTag, setTag }: AddTagModal) 
             }}
             autoFocus
           />
-          <p className="text-xs text-gray-400 ml-1 mb-4">* 쉼표로 구분하여 입력하세요.</p>
+          <p className="text-xs text-gray-400 ml-1">* 쉼표로 구분하여 입력하세요.</p>
+          <p className="text-xs text-gray-400 ml-1 mb-4">
+            각 태그는 최대 {maxLabel}자까지 입력할 수 있습니다.
+          </p>
 
           <ModalActionButtons onSave={handleSave} onCancel={onClose} />
         </motion.div>

--- a/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
+++ b/src/pages/LayoutWithoutFooter/RetrospectWritePage.tsx
@@ -17,6 +17,7 @@ import FormActionButtons from "@/components/common/FormActionButtons";
 import RetrospectTimer from "@/components/features/retrospect/RetrospectTimer";
 import RetrospectTagSelector from "@/components/features/retrospect/RetrospectTagSelector";
 import AlertPopup from "@/components/common/AlertPopup";
+import toast from "react-hot-toast";
 
 export default function RetrospectWritePage() {
   const navigate = useNavigate();
@@ -31,6 +32,8 @@ export default function RetrospectWritePage() {
   const [note, setNote] = useState("");
   const [tags, setTags] = useState<string[]>([]);
   const [showAlert, setShowAlert] = useState(false);
+
+  const maxNote = 100;
 
   useEffect(() => {
     if (retrospect) {
@@ -71,6 +74,15 @@ export default function RetrospectWritePage() {
     navigate(lastPage);
   };
 
+  const handleChangeNote = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value.length > maxNote) {
+      toast.error(`회고는 최대 ${maxNote}자까지 입력할 수 있어요.`);
+      return;
+    }
+
+    setNote(e.target.value);
+  };
+
   return (
     <div>
       <PageHeader
@@ -85,14 +97,17 @@ export default function RetrospectWritePage() {
         <Schedule scheduleId={scheduleId} isMini={false} />
 
         {/* 노트 작성 */}
-        <div className="mt-6 mb-5">
+        <div className="mt-6 mb-5 relative ">
           <label className="block mb-1 font-bold">노트</label>
           <textarea
             value={note}
-            onChange={(e) => setNote(e.target.value)}
+            onChange={handleChangeNote}
             placeholder="내용을 입력하세요."
             className="w-full text-sm border p-2 rounded resize-none h-32 bg-white focus:outline-none focus:ring-1 focus:ring-primary"
-          />
+          ></textarea>
+          <div className="absolute bottom-3 right-3 text-xs">
+            {note.length} / {maxNote}
+          </div>
         </div>
 
         {/* 태그 선택 */}

--- a/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
+++ b/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
@@ -65,7 +65,7 @@ export default function ScheduleFormPage() {
       time: formatTimeOnly(selectedDate),
       title,
       memo,
-      category: category.id,
+      category: category?.id,
       done: schedule?.done ?? false,
     };
 

--- a/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
+++ b/src/pages/LayoutWithoutFooter/ScheduleFormPage.tsx
@@ -35,7 +35,9 @@ export default function ScheduleFormPage() {
   const [selectedDate, setSelectedDate] = useState<Date>(
     state?.selectedDate ? new Date(state.selectedDate) : new Date(),
   );
-  const [category, setCategory] = useState<CategoryType>(categories[0]);
+  const [category, setCategory] = useState<CategoryType | null>(
+    categories !== null ? categories[0] : null,
+  );
   const setSchedules = useSetRecoilState(scheduleState);
   const [showAlert, setShowAlert] = useState(false);
   const setRetrospects = useSetRecoilState(retrospectState);

--- a/src/recoil/retrospect/types.ts
+++ b/src/recoil/retrospect/types.ts
@@ -4,6 +4,6 @@ export interface RetrospectType {
   date: string;
   focusDuration: number;
   content: string;
-  category: string;
+  category?: string;
   tags?: string[];
 }

--- a/src/recoil/schedule/types.ts
+++ b/src/recoil/schedule/types.ts
@@ -5,5 +5,5 @@ export interface ScheduleType {
   title: string;
   memo?: string;
   done: boolean;
-  category: string;
+  category?: string;
 }


### PR DESCRIPTION
## ✨ 주요 변경 사항

### 🏷️ 입력 글자수 제한
- 회고 작성 내용에 최대 글자 수 제한 적용 (ex. 100자)
- 태그는 한 개당 10자 이내로 제한
- 초과 시 사용자에게 토스트 알림 노출

### 🐞 카테고리 삭제 이슈 수정
- 카테고리 삭제 시 연관된 스케줄/상태와의 연결 오류 수정
- 삭제 이후에도 UI 및 데이터 일관성 유지

---

## ✅ 테스트 항목

- [x] 태그 10자 초과 시 추가되지 않음
- [x] 회고 100자 초과 시 작성 불가 및 경고 표시
- [x] 카테고리 삭제 후 관련 스케줄이 깨지지 않음